### PR TITLE
Add support for npm install flag

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -222,12 +222,13 @@ INCLUDE_PATH="$VENDORED_NODE/include"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 
-# install dependencies with npm
-echo "-----> Installing dependencies with npm"
-run_npm "install --production"
-run_npm "rebuild"
-echo "Dependencies installed" | indent
-
+if [ "${useNpm}" == "true" ]; then
+	# install dependencies with npm
+	echo "-----> Installing dependencies with npm"
+	run_npm "install --production"
+	run_npm "rebuild"
+	echo "Dependencies installed" | indent
+fi
 echo "-----> Building runtime environment"
 mkdir -p $BUILD_DIR/.profile.d
 echo "export PATH=\"\$HOME/bin:\$HOME/node_modules/.bin:\$PATH\"" > $BUILD_DIR/.profile.d/nodejs.sh


### PR DESCRIPTION
Adds support to disable npm install by using a 'cfNpmInstall':false flag in the engine section of the application's package.json file.  Default is to use 'npm install'.

This will allow nodejs builds to be executed prior to running on cloudfoundry and can prevent external npm registry requirements essentially allowing the build to happen prior to pushing the application up.

The flag is turned off by default, leaving the default 'npm install' behavior the same as is it today.  It simply extends the option.  This is an example of the engines section of the package.json file:

   "engines": {
    "cfNpmInstall":false,
    "node": "0.8.x",
    "npm": "= 1.2.12"
  }
