### PR TITLE
remove post to nomnom

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -109,16 +109,3 @@ fi
 status "Building runtime environment"
 mkdir -p $build_dir/.profile.d
 echo "export PATH=\"\$HOME/vendor/node/bin:\$HOME/bin:\$HOME/node_modules/.bin:\$PATH\";" > $build_dir/.profile.d/nodejs.sh
-
-# Post package.json to nomnom service
-# Use a subshell so failures won't break the build.
-(
-  curl \
-    --data @$build_dir/package.json \
-    --fail \
-    --silent \
-    --request POST \
-    --header "content-type: application/json" \
-    https://nomnom.heroku.com/?request_id=$REQUEST_ID \
-    > /dev/null
-) &


### PR DESCRIPTION
In the heroku buildpack, the package.json file is posted to a nomnom.heroku.com service.  That bit of code is not needed or desired.
