### PR TITLE
Fix npm to allow self signed certs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -78,6 +78,7 @@ fi
 
   status "Installing dependencies"
   # Make npm output to STDOUT instead of its default STDERR
+  npm config set ca ""
   npm install --userconfig $build_dir/.npmrc --production 2>&1 | indent
 )
 


### PR DESCRIPTION
This allows self signed certs to continue to function after it was ripped out at random breaking aws elastic beanstalk, azure, heroku, and cloud foundry. 
