### PR TITLE
Fix: filter of non existing dependencies for offline buildpack

### DIFF
--- a/bin/package
+++ b/bin/package
@@ -2,8 +2,17 @@
 set -euo pipefail
 
 language='nodejs'
+dependencies=()
+excludes=()
 
-dependencies=(`curl -s https://semver.io/node/versions | awk '{ printf "http://s3pository.heroku.com/node/v%s/node-v%s-linux-x64.tar.gz ", $1, $1 }'`)
+for version in `curl -s https://semver.io/node/versions`; do
+   url=$(printf "http://s3pository.heroku.com/node/v%s/node-v%s-linux-x64.tar.gz " $version $version)
+   if `curl --output /dev/null --silent --head --fail $url`; then
+      dependencies+=($url)
+   else
+      excludes+=($version)
+   fi
+done
 
 excluded_files=(
   '.git/'
@@ -19,7 +28,14 @@ excluded_files=(
 BIN="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 mkdir -p $BIN/../files
-curl https://semver.io/node.json > $BIN/../files/versions.json
+rm -f $BIN/../files/versions.json
+versfile=`curl -s https://semver.io/node.json`
+
+for exclude in ${excludes[@]}; do
+  versfile=`echo $versfile | sed 's/'$exclude'//g' | sed 's/\"\"//g' | sed 's/,,/,/g'` 
+done
+
+echo $versfile > $BIN/../files/versions.json
 
 source $BIN/../buildpack-packager/lib/packager
 


### PR DESCRIPTION
The creation of an offline buildpack is failing in cause of non existing dependencies. The changes in the bin/package script will do a check in advance and then filter out the incorrect versions.
