### PR TITLE
Fix small typo in link to CF buildpack docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Cloud Foundry [buildpack](http://docs.cloudfoundry.org/buildpacks/) for Node b
 
 This is based on the [Heroku buildpack] (https://github.com/heroku/heroku-buildpack-nodejs).
 
-Additional documentation can be found at the [CloundFoundry.org](http://docs.cloudfoundry.org/buildpacks/).
+Additional documentation can be found at the [CloudFoundry.org](http://docs.cloudfoundry.org/buildpacks/).
 
 ## Usage
 


### PR DESCRIPTION
"Clou**n**dFoundry" vs "CloudFoundry"