### PR TITLE
Add env var to stop rebuilding dependencies when compile

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -160,13 +160,16 @@ install_npm() {
 
 build_dependencies() {
   restore_cache
-
+  norebuild=${NO_REBUILD:=no}
   if [ "$modules_source" == "" ]; then
     info "Skipping dependencies (no source for node_modules)"
 
-  elif [ "$modules_source" == "prebuilt" ]; then
+  elif [ "$modules_source" == "prebuilt" ] && [ "$norebuild" == "no" ]; then
     info "Rebuilding any native modules for this architecture"
     npm rebuild 2>&1 | indent
+
+  elif [ "$modules_source" == "prebuilt" ] && [ "$norebuild" != "no" ]; then
+    info "No rebuild"
 
   else
     info "Installing node modules"


### PR DESCRIPTION
You can see discussions from here: https://github.com/cloudfoundry/nodejs-buildpack/pull/11 and here https://github.com/cloudfoundry/nodejs-buildpack/issues/6 

It's just to fix the rebuild problem by let's the possibility for the user to no rebuild (by default buildpack will rebuild dependencies).
For no rebuild you have to set an en var: `NO_REBUILD` to `true`.

Your nodejs app should be build and install dependencies before pushing to Cloud Foundry you can do it with travis for example.

A good usecase is to try to install https://github.com/cloudfoundry-community/etherpad-lite-cf in offline mode (follow the README) and set NO_REBUILD.

This fix is also to have an option before something better will be made.