### PR TITLE
Align npm dependencies logic with legacy behavior

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -159,7 +159,6 @@ install_npm() {
 }
 
 build_dependencies() {
-  restore_cache
 
   if [ "$modules_source" == "" ]; then
     info "Skipping dependencies (no source for node_modules)"
@@ -169,6 +168,7 @@ build_dependencies() {
     npm rebuild 2>&1 | indent
 
   else
+    restore_cache
     info "Installing node modules"
     npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
   fi

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -166,6 +166,8 @@ build_dependencies() {
   elif [ "$modules_source" == "prebuilt" ]; then
     info "Rebuilding any native modules for this architecture"
     npm rebuild 2>&1 | indent
+    info "Installing any new modules"
+    npm install --unsafe-perm --quiet --userconfig $build_dir/.npmrc 2>&1 | indent
 
   else
     restore_cache


### PR DESCRIPTION
Spawned from issue #20 and #22
1) Turn caching off if `node_modules` is pushed with application
2) Install new modules if `node_modules` is pushed with the application, not only rebuild the existing ones.