### PR TITLE
fix issue where NPM cannot be found

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -63,6 +63,7 @@ warn_missing_package_json "$BUILD_DIR"
 
 create_env() {
   write_profile "$BP_DIR" "$BUILD_DIR"
+  write_export "$BP_DIR" "$BUILD_DIR"
   export_env_dir "$ENV_DIR"
   create_default_env
 }


### PR DESCRIPTION
This PR fixes an issue where npm cannot be found during a multi-buildpack deploy. I understand the multi-buildpack is not officially supported, but wanted to give it a shot.

#### Background

The upstream fork has the following line of code as well.

Calling `write_export` sets `NODE_HOME`. Without it, I'm seeing an error when running `rake assets:precompile` for an app with the `ember-cli-rails` .gem, resulting in an error where `npm` cannot be found. `which npm` returns nil.

The error I was seeing: 

```
Running: rake assets:precompile
ERROR: Failed command: ` prune &&  install`
```

The command should read: `npm prune && npm install`, and now it does.

I could definitely use a hand on tests for this as well.

