### PR TITLE
Fix detection

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-BP=$("dirname $("dirname $0")")
+BP=$(dirname "$(dirname $0)")
 if [ -f "$1/package.json" ]; then
-  echo "node.js $("cat $BP/VERSION")"
+  echo "node.js "$(cat "$BP/VERSION")"
   exit 0
 fi
 

--- a/bin/detect
+++ b/bin/detect
@@ -3,7 +3,7 @@
 
 BP=$(dirname "$(dirname $0)")
 if [ -f "$1/package.json" ]; then
-  echo "node.js "$(cat "$BP/VERSION")"
+  echo "node.js "$(cat "$BP/VERSION")""
   exit 0
 fi
 

--- a/cf_spec/integration/deploy_a_node_app_spec.rb
+++ b/cf_spec/integration/deploy_a_node_app_spec.rb
@@ -2,8 +2,11 @@ $: << 'cf_spec'
 require 'spec_helper'
 
 describe 'CF NodeJS Buildpack' do
-  subject(:app) { Machete.deploy_app(app_name) }
-  let(:browser) { Machete::Browser.new(app) }
+  subject(:app)           { Machete.deploy_app(app_name) }
+  let(:browser)           { Machete::Browser.new(app) }
+  let(:buildpack_dir)     { File.join(File.dirname(__FILE__), '..', '..') }
+  let(:version_file)      { File.join(buildpack_dir, 'VERSION') }
+  let(:buildpack_version) { File.read(version_file).strip }
 
   after do
     Machete::CF::DeleteApp.new.execute(app)
@@ -54,6 +57,10 @@ describe 'CF NodeJS Buildpack' do
 
       browser.visit_path('/')
       expect(browser).to have_body('Hello, World!')
+    end
+
+    it 'correctly displays the buildpack version' do
+      expect(app).to have_logged "node.js #{buildpack_version}"
     end
   end
 


### PR DESCRIPTION
These missing quotes don't break detection, but they likely cause the buildpack to provide invalid detect metadata.