### PR TITLE
Fix `WEB_CONCURRENCY` and `WEB_MEMORY` from being overwritten at runtime

### DIFF
--- a/src/nodejs/supply/supply.go
+++ b/src/nodejs/supply/supply.go
@@ -232,6 +232,8 @@ func (s *Supplier) CreateDefaultEnv() error {
 		"NPM_CONFIG_LOGLEVEL":   "error",
 		"NODE_MODULES_CACHE":    "true",
 		"NODE_VERBOSE":          "false",
+		"WEB_MEMORY":            "512",
+		"WEB_CONCURRENCY":       "1",
 	}
 
 	s.Log.BeginStep("Creating runtime environment")
@@ -251,8 +253,8 @@ func (s *Supplier) CreateDefaultEnv() error {
 	scriptContents := `export NODE_HOME=%s
 export NODE_ENV=${NODE_ENV:-production}
 export MEMORY_AVAILABLE=$(echo $VCAP_APPLICATION | jq '.limits.mem')
-export WEB_MEMORY=512
-export WEB_CONCURRENCY=1
+export WEB_MEMORY=${WEB_MEMORY:-512}
+export WEB_CONCURRENCY=${WEB_CONCURRENCY:-1}
 `
 
 	return s.Stager.WriteProfileD("node.sh", fmt.Sprintf(scriptContents, filepath.Join("$DEPS_DIR", s.Stager.DepsIdx(), "node")))

--- a/src/nodejs/supply/supply_test.go
+++ b/src/nodejs/supply/supply_test.go
@@ -475,6 +475,8 @@ var _ = Describe("Supply", func() {
 			Entry("NPM_CONFIG_LOGLEVEL", "NPM_CONFIG_LOGLEVEL", "everything"),
 			Entry("NODE_MODULES_CACHE", "NODE_MODULES_CACHE", "false"),
 			Entry("NODE_VERBOSE", "NODE_VERBOSE", "many words"),
+			Entry("WEB_MEMORY", "WEB_MEMORY", "a value"),
+			Entry("WEB_CONCURRENCY", "WEB_CONCURRENCY", "another value")
 		)
 
 		DescribeTable("environment with default was not set",
@@ -494,6 +496,8 @@ var _ = Describe("Supply", func() {
 			Entry("NPM_CONFIG_LOGLEVEL", "NPM_CONFIG_LOGLEVEL", "error"),
 			Entry("NODE_MODULES_CACHE", "NODE_MODULES_CACHE", "true"),
 			Entry("NODE_VERBOSE", "NODE_VERBOSE", "false"),
+			Entry("WEB_MEMORY", "WEB_MEMORY", "512"),
+			Entry("WEB_CONCURRENCY", "WEB_CONCURRENCY", "1")
 		)
 
 		It("writes profile.d script for runtime", func() {


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This updates the generated default config file for node_home to follow the user provided `WEB_CONCURRENCY` and `WEB_MEMORY` if provided, otherwise it will use the defaults it currently uses.

I've skipped the tests as the contribution guide is unclear on this specific go component should be tested. I'm happy to take feedback on this.

* An explanation of the use cases your change solves

This fixes a bug where the  `WEB_CONCURRENCY` environment variable is ignored and overwritten with 1 at runtime which prevents forking of processes greater than 1.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
