### PR TITLE
Fix `bufio.Scanner: token too long` error

### DIFF
--- a/src/nodejs/finalize/finalize.go
+++ b/src/nodejs/finalize/finalize.go
@@ -3,7 +3,6 @@ package finalize
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -392,7 +391,6 @@ func fileHasString(file string, patterns ...string) (bool, error) {
 		line, err = reader.ReadString('\n')
 	}
 	if err != io.EOF {
-		fmt.Println(err)
 		return false, err
 	}
 

--- a/src/nodejs/finalize/finalize.go
+++ b/src/nodejs/finalize/finalize.go
@@ -3,6 +3,7 @@ package finalize
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -379,18 +380,21 @@ func fileHasString(file string, patterns ...string) (bool, error) {
 		return false, err
 	}
 	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
+	reader := bufio.NewReader(f)
+	line, err := reader.ReadString('\n')
+	for err == nil {
+		src := strings.ToLower(line)
 		for _, pat := range patterns {
-			src := strings.ToLower(scanner.Text())
-
 			if strings.Contains(src, pat) {
 				return true, nil
 			}
 		}
+		line, err = reader.ReadString('\n')
 	}
-	if err := scanner.Err(); err != nil {
+	if err != io.EOF {
+		fmt.Println(err)
 		return false, err
 	}
+
 	return false, nil
 }


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Convert the `fileHasString` function to use `bufio.Reader` instead of `bufio.Scanner`

* An explanation of the use cases your change solves
When deploying an application the uses the `ibm_db` node_module an end user will get this error when when using npm as the package manager. It apears to happen because the verbose logging that occurs when this particular module is installed. This behavior does not occur when using `yarn`.
```
---snippped---
99.64% | 18636800 bytes downloaded out of 18703240 bytes.
99.69% | 18644992 bytes downloaded out of 18703240 bytes.
99.73% | 18653184 bytes downloaded out of 18703240 bytes.
99.78% | 18661376 bytes downloaded out of 18703240 bytes.
99.82% | 18669568 bytes downloaded out of 18703240 bytes.
99.86% | 18677760 bytes downloaded out of 18703240 bytes.
99.91% | 18685952 bytes downloaded out of 18703240 bytes.
100.00% | 18702336 bytes downloaded out of 18703240 bytes.
99.95% | 18694144 bytes downloaded out of 18703240 bytes.
100.00% | 18703240 bytes downloaded out of 18703240 bytes.
****************************************
You are downloading a package which includes the Node.js module for IBM DB2/Informix.  The module is licensed under the Apache License 2.0. The package also includes IBM ODBC and CLI Driver
 from IBM, which is automatically downloaded as the node module is installed on your system/device. The license agreement to the IBM ODBC and CLI Driver is available in /tmp/app/node_module
s/ibm_db/installer   Check for additional dependencies, which may come with their own license agreement(s). Your use of the components of the package and dependencies constitutes your accep
tance of their respective license agreements. If you do not accept the terms of any license agreement(s), then delete the relevant component(s) from your device.

****************************************
Downloading and extraction of DB2 ODBC CLI Driver completed successfully ...
make: Entering directory `/tmp/app/node_modules/ibm_db/build'
  CXX(target) Release/obj.target/odbc_bindings/src/odbc.o
  CXX(target) Release/obj.target/odbc_bindings/src/odbc_connection.o
  CXX(target) Release/obj.target/odbc_bindings/src/odbc_statement.o
  CXX(target) Release/obj.target/odbc_bindings/src/odbc_result.o
  SOLINK_MODULE(target) Release/obj.target/odbc_bindings.node
  COPY Release/odbc_bindings.node
make: Leaving directory `/tmp/app/node_modules/ibm_db/build'
added 138 packages in 75.975s
-----> Caching build
       Clearing previous node cache
       Saving 3 cacheDirectories (default):
       - .npm
       - .cache/yarn
       - bower_components (nothing to cache)
       **ERROR** bufio.Scanner: token too long
Failed to compile droplet
Exit status 223
Staging failed: Exited with status 223
Destroying container
Successfully destroyed container
```
* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
