### PR TITLE
Supports appdynamics via user provided service

### DIFF
--- a/profile/appdynamics-setup.sh
+++ b/profile/appdynamics-setup.sh
@@ -3,12 +3,12 @@ FILTER="appdynamics\|app-dynamics"
 if [ `echo $VCAP_SERVICES | grep -c $FILTER ` -gt 0 ];
 then
   key="appdynamics"
-  APPDYNAMICS_CONTROLLER_HOST_NAME=$(echo "${VCAP_SERVICES-}" | jq -r '.['\""$key"\"'][0] | .credentials | .["host-name"] ')
-  APPDYNAMICS_CONTROLLER_PORT=$(echo "${VCAP_SERVICES-}" | jq -r '.['\""$key"\"'][0] | .credentials | .port ')
-  APPDYNAMICS_AGENT_ACCOUNT_NAME=$(echo "${VCAP_SERVICES-}" | jq -r '.['\""$key"\"'][0] | .credentials | .["account-name"] ')
+  APPDYNAMICS_CONTROLLER_HOST_NAME=$(echo "${VCAP_SERVICES-}" | jq -r --arg key $key '[.[][] | select(.name | contains($key))][0] | .credentials | .["host-name"]')
+  APPDYNAMICS_CONTROLLER_PORT=$(echo "${VCAP_SERVICES-}" | jq -r --arg key $key '[.[][] | select(.name | contains($key))][0] | .credentials | .port')
+  APPDYNAMICS_AGENT_ACCOUNT_NAME=$(echo "${VCAP_SERVICES-}" | jq -r --arg key $key '[.[][] | select(.name | contains($key))][0] | .credentials | .["account-name"]')
 
-  APPDYNAMICS_CONTROLLER_SSL_ENABLED=$(echo "${VCAP_SERVICES-}" | jq -r '.['\""$key"\"'][0] | .credentials | .["ssl-enabled"] ')
-  APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY=$(echo "${VCAP_SERVICES-}" | jq -r '.['\""$key"\"'][0] | .credentials | .["account-access-key"] ')
+  APPDYNAMICS_CONTROLLER_SSL_ENABLED=$(echo "${VCAP_SERVICES-}" | jq -r --arg key $key '[.[][] | select(.name | contains($key))][0] | .credentials | .["ssl-enabled"]')
+  APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY=$(echo "${VCAP_SERVICES-}" | jq -r --arg key $key '[.[][] | select(.name | contains($key))][0] | .credentials | .["account-access-key"]')
   APPDYNAMICS_AGENT_APPLICATION_NAME=$(echo "${VCAP_APPLICATION-}" | jq -r .application_name)
   APPDYNAMICS_AGENT_TIER_NAME=$(echo "${VCAP_APPLICATION-}" | jq -r .application_name)
   APPDYNAMICS_AGENT_NODE_NAME_PREFIX=$(echo "${APPDYNAMICS_AGENT_TIER_NAME}")


### PR DESCRIPTION
## Proposed change

Modifies the `jq` filter to search for the first occurrence of _any_ service who's name contains `appdynamics` to source credentials from.

## Use cases the change solves

This allows a user provided service or brokered service with a name containing `appdynamics` to be used instead of _only_ a brokered service.



* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test

I'll take a look at adding an integration test and getting the CLA signed. Just wanted to get it out here for comment in the meantime.

