### PR TITLE
Bugfix for Dynatrace hook

### DIFF
--- a/src/nodejs/hooks/dynatrace.go
+++ b/src/nodejs/hooks/dynatrace.go
@@ -134,7 +134,7 @@ func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 	return nil
 }
 
-func (h DynatraceHook) GetCredentialString(credentials map[string]interface{},key string) string {
+func (h DynatraceHook) getCredentialString(credentials map[string]interface{},key string) string {
 	value, isString := credentials[key].(string)
 
 	if isString {
@@ -145,9 +145,9 @@ func (h DynatraceHook) GetCredentialString(credentials map[string]interface{},ke
 
 func (h DynatraceHook) dtCredentials() (DynatraceCredentials, bool) {
 	type Service struct {
-        Name        string            `json:"name"`
-        Credentials map[string]interface{} `json:"credentials"`
-    }
+		Name        string                 `json:"name"`
+		Credentials map[string]interface{} `json:"credentials"`
+	}
 
 	var vcapServices map[string][]Service
 
@@ -162,12 +162,13 @@ func (h DynatraceHook) dtCredentials() (DynatraceCredentials, bool) {
 	for _, services := range vcapServices {
 		for _, service := range services {
 			if strings.Contains(service.Name, "dynatrace") {
-				var credentials DynatraceCredentials
-				credentials.ServiceName = service.Name
-				credentials.EnvironmentId = h.GetCredentialString(service.Credentials, "environmentid")
-				credentials.ApiToken = h.GetCredentialString(service.Credentials, "apitoken")
-				credentials.ApiURL = h.GetCredentialString(service.Credentials, "apiurl")
-				credentials.SkipErrors = h.GetCredentialString(service.Credentials, "skiperrors") == "true"
+				credentials := DynatraceCredentials{
+					ServiceName :   service.Name,
+					EnvironmentId : h.getCredentialString(service.Credentials, "environmentid"),
+					ApiToken :      h.getCredentialString(service.Credentials, "apitoken"),
+					ApiURL :        h.getCredentialString(service.Credentials, "apiurl"),
+					SkipErrors :    h.getCredentialString(service.Credentials, "skiperrors") == "true",
+				}
 
 				if credentials.EnvironmentId != "" && credentials.ApiToken != "" {
 					detectedCredentials = append(detectedCredentials, credentials)

--- a/src/nodejs/hooks/dynatrace.go
+++ b/src/nodejs/hooks/dynatrace.go
@@ -17,6 +17,13 @@ type Command interface {
 	Execute(string, io.Writer, io.Writer, string, ...string) error
 }
 
+type DynatraceCredentials struct {
+	ServiceName string
+	EnvironmentId string
+	ApiToken string
+	ApiURL string
+	SkipErrors bool
+}
 type DynatraceHook struct {
 	libbuildpack.DefaultHook
 	Log     *libbuildpack.Logger
@@ -36,28 +43,26 @@ func init() {
 func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 	h.Log.Debug("Checking for enabled dynatrace service...")
 
-	credentials := h.dtCredentials()
-	if credentials == nil {
+	credentials, found := h.dtCredentials()
+	if !found {
 		h.Log.Debug("Dynatrace service credentials not found!")
 		return nil
 	}
 
 	h.Log.Info("Dynatrace service credentials found. Setting up Dynatrace PaaS agent.")
 
-	skipErrors := credentials["skiperrors"]
-
-	apiurl, present := credentials["apiurl"]
-	if !present {
-		apiurl = "https://" + credentials["environmentid"] + ".live.dynatrace.com/api"
+	apiurl := credentials.ApiURL
+	if apiurl == "" {
+		apiurl = "https://" + credentials.EnvironmentId + ".live.dynatrace.com/api"
 	}
 
-	url := apiurl + "/v1/deployment/installer/agent/unix/paas-sh/latest?include=nodejs&include=process&bitness=64&Api-Token=" + credentials["apitoken"]
+	url := apiurl + "/v1/deployment/installer/agent/unix/paas-sh/latest?include=nodejs&include=process&bitness=64&Api-Token=" + credentials.ApiToken
 	installerPath := filepath.Join(os.TempDir(), "paasInstaller.sh")
 
 	h.Log.Debug("Downloading '%s' to '%s'", url, installerPath)
 	err := h.downloadFile(url, installerPath)
 	if err != nil {
-		if skipErrors == "true" {
+		if credentials.SkipErrors {
 			h.Log.Warning("Error during installer download, skipping installation")
 			return nil
 		}
@@ -129,38 +134,56 @@ func (h DynatraceHook) AfterCompile(stager *libbuildpack.Stager) error {
 	return nil
 }
 
-func (h DynatraceHook) dtCredentials() map[string]string {
-	type Service struct {
-		Name        string            `json:"name"`
-		Credentials map[string]string `json:"credentials"`
+func (h DynatraceHook) GetCredentialString(credentials map[string]interface{},key string) string {
+	value, isString := credentials[key].(string)
+
+	if isString {
+		return value
 	}
+	return ""
+}
+
+func (h DynatraceHook) dtCredentials() (DynatraceCredentials, bool) {
+	type Service struct {
+        Name        string            `json:"name"`
+        Credentials map[string]interface{} `json:"credentials"`
+    }
+
 	var vcapServices map[string][]Service
 
 	err := json.Unmarshal([]byte(os.Getenv("VCAP_SERVICES")), &vcapServices)
 	if err != nil {
-		return nil
+		h.Log.Debug("Failed to unmarshal VCAP_SERVICES: %s", err)
+		return DynatraceCredentials{}, false
 	}
 
-	var detectedServices []Service
+	var detectedCredentials []DynatraceCredentials
 
 	for _, services := range vcapServices {
 		for _, service := range services {
-			if strings.Contains(service.Name, "dynatrace") &&
-					service.Credentials["environmentid"] != "" &&
-					service.Credentials["apitoken"] != "" {
-				detectedServices = append(detectedServices, service)
+			if strings.Contains(service.Name, "dynatrace") {
+				var credentials DynatraceCredentials
+				credentials.ServiceName = service.Name
+				credentials.EnvironmentId = h.GetCredentialString(service.Credentials, "environmentid")
+				credentials.ApiToken = h.GetCredentialString(service.Credentials, "apitoken")
+				credentials.ApiURL = h.GetCredentialString(service.Credentials, "apiurl")
+				credentials.SkipErrors = h.GetCredentialString(service.Credentials, "skiperrors") == "true"
+
+				if credentials.EnvironmentId != "" && credentials.ApiToken != "" {
+					detectedCredentials = append(detectedCredentials, credentials)
+				}
 			}
 		}
 	}
 
-	if len(detectedServices) == 1 {
-		h.Log.Debug("Found one matching service: %s", detectedServices[0].Name)
-		return detectedServices[0].Credentials
-	} else if len(detectedServices) > 1 {
+	if len(detectedCredentials) == 1 {
+		h.Log.Debug("Found one matching service: %s", detectedCredentials[0].ServiceName)
+		return detectedCredentials[0], true
+	} else if len(detectedCredentials) > 1 {
 		h.Log.Warning("More than one matching service found!")
 	}
 
-	return nil
+	return DynatraceCredentials{}, false
 }
 
 func (h DynatraceHook) appName() string {

--- a/src/nodejs/hooks/dynatrace_test.go
+++ b/src/nodejs/hooks/dynatrace_test.go
@@ -164,7 +164,7 @@ var _ = Describe("dynatraceHook", func() {
 				environmentid := "123456"
 				os.Setenv("VCAP_APPLICATION", `{"name":"JimBob"}`)
 				os.Setenv("VCAP_SERVICES", `{
-					"0": [{"name":"dynatrace","credentials":{"apiurl":"https://example.com","environmentid":"`+environmentid+`"}}],
+					"0": [{"name":"dynatrace","credentials":{"apiurl":"https://example.com","environmentid":"`+environmentid+`"}}]
 				}`)
 			})
 
@@ -207,7 +207,45 @@ var _ = Describe("dynatraceHook", func() {
 			})
 		})
 
-		Context("VCAP_SERVICES contains dynatrace service using environmentid", func() {
+		Context("VCAP_SERVICES contains malformed dynatrace service", func() {
+			BeforeEach(func() {
+				environmentid := "123456"
+				apiToken := "ExcitingToken28"
+				os.Setenv("VCAP_APPLICATION", `{"name":"JimBob"}`)
+				os.Setenv("VCAP_SERVICES", `{
+					"0": [{"name":"mysql"}],
+					"1": [{"name":"dynatrace","credentials":{"apiurl":"https://example.com","apitoken":"`+apiToken+`","environmentid":{ "id":"`+environmentid+`"}}}],
+					"2": [{"name":"redis"}]
+				}`)
+			})
+			
+			It("does nothing and succeeds", func() {
+				err = dynatrace.AfterCompile(stager)
+				Expect(err).To(BeNil())
+
+				Expect(buffer.String()).To(Equal(""))
+			})
+		})
+
+		Context("VCAP_SERVICES contains dynatrace service without credentials", func() {
+			BeforeEach(func() {
+				os.Setenv("VCAP_APPLICATION", `{"name":"JimBob"}`)
+				os.Setenv("VCAP_SERVICES", `{
+					"0": [{"name":"mysql"}],
+					"1": [{"name":"dynatrace"}],
+					"2": [{"name":"redis"}]
+				}`)
+			})
+			
+			It("does nothing and succeeds", func() {
+				err = dynatrace.AfterCompile(stager)
+				Expect(err).To(BeNil())
+
+				Expect(buffer.String()).To(Equal(""))
+			})
+		})
+
+		Context("VCAP_SERVICES contains dynatrace service using environmentid and redis service", func() {
 			BeforeEach(func() {
 				environmentid := "123456"
 				apiToken := "ExcitingToken28"
@@ -215,14 +253,14 @@ var _ = Describe("dynatraceHook", func() {
 				os.Setenv("VCAP_SERVICES", `{
 					"0": [{"name":"mysql"}],
 					"1": [{"name":"dynatrace","credentials":{"environmentid":"`+environmentid+`","apitoken":"`+apiToken+`"}}],
-					"2": [{"name":"redis"}]
+					"2": [{"name":"redis", "credentials":{"db_type":"redis", "instance_administration_api":{"deployment_id":"12345asdf", "instance_id":"12345asdf", "root":"https://doesnotexi.st"}}}]
 				}`)
 
 				httpmock.RegisterResponder("GET", "https://123456.live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas-sh/latest?include=nodejs&include=process&bitness=64&Api-Token="+apiToken,
 					httpmock.NewStringResponder(200, "echo Install Dynatrace"))
 			})
 
-			It("installs dyntatrace", func() {
+			It("installs dynatrace", func() {
 				mockCommand.EXPECT().Execute("", gomock.Any(), gomock.Any(), gomock.Any(), buildDir).Do(runInstaller)
 
 				err = dynatrace.AfterCompile(stager)

--- a/src/nodejs/integration/nodejs_app_with_dynatrace_test.go
+++ b/src/nodejs/integration/nodejs_app_with_dynatrace_test.go
@@ -147,5 +147,43 @@ var _ = Describe("CF NodeJS Buildpack", func() {
 			Expect(app.GetBody("/")).To(ContainSubstring("\"DT_HOST_ID\":\"" + app.Name + "_0\""))
 		})
 	})
+
+	Context("deploying a NodeJS app with Dynatrace agent with single credentials service and a redis service", func() {
+		It("checks if Dynatrace injection was successful", func() {
+
+			serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", serviceName, "-p", "'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"https://s3.amazonaws.com/dt-paas/manifest\",\"environmentid\":\"envid\"}'")
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, serviceName)
+			command = exec.Command("cf", "bind-service", app.Name, serviceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+
+			redisServiceName := "redis-" + cutlass.RandStringRunes(20) + "-service"
+			command = exec.Command("cf", "cups", redisServiceName, "-p", "'{\"name\":\"redis\", \"credentials\":{\"db_type\":\"redis\", \"instance_administration_api\":{\"deployment_id\":\"12345asdf\", \"instance_id\":\"12345asdf\", \"root\":\"https://doesnotexi.st\"}}}'")
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, serviceName)
+			command = exec.Command("cf", "bind-service", app.Name, redisServiceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace service credentials found. Setting up Dynatrace PaaS agent."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Starting Dynatrace PaaS agent installer"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Copy dynatrace-env.sh"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent installed."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace PaaS agent injection is set up."))
+
+			Expect(app.GetBody("/")).To(ContainSubstring("\"DT_HOST_ID\":\"" + app.Name + "_0\""))
+		})
+	})
+
+	
 })
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Fixed a bug where our installer wasn't started when there was a service bound that had a JSON object in the credentials.

* An explanation of the use cases your change solves

Before, we only looked for key-value-pairs in the credentials of services, which resulted in an unmarshaling error when there was anything else in there, eg. a JSON object.
Adapted the credentials checking and extraction to make it a bit more general and forgiving in that regard.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
