### PR TITLE
Add support for custom api url and snyk org

### DIFF
--- a/fixtures/fake_snyk_service_broker/Gemfile
+++ b/fixtures/fake_snyk_service_broker/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gem 'roda'

--- a/fixtures/fake_snyk_service_broker/Gemfile.lock
+++ b/fixtures/fake_snyk_service_broker/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    rack (2.0.3)
+    roda (3.1.0)
+      rack
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  roda
+
+BUNDLED WITH
+   1.15.4

--- a/fixtures/fake_snyk_service_broker/catalog.json
+++ b/fixtures/fake_snyk_service_broker/catalog.json
@@ -1,0 +1,38 @@
+{
+  "services": [
+    {
+      "id": "8aafea94-a83e-4154-bf37-fb81112b942f",
+      "name": "snyk",
+      "description": "fake snyk broker",
+      "bindable": true,
+      "tags": [],
+      "metadata": {
+        "displayName": "snyk",
+        "imageUrl": "http://via.placeholder.com/100x100",
+        "longDescription": "fake snyk broker",
+        "providerDisplayName": "snyk",
+        "documentationUrl": "http://example.com",
+        "supportUrl": "http://example.com"
+      },
+      "plans": [
+        {
+          "id": "fd780893-9d2d-47b0-9534-3dfc62290083",
+          "name": "public",
+          "description": "fake snyk broker",
+          "metadata": {
+            "bullets": [],
+            "costs": [
+              {
+                "amount": {
+                  "usd": 0
+                },
+                "unit": "MONTHLY"
+              }
+            ],
+            "displayName": "public"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/fake_snyk_service_broker/config.ru
+++ b/fixtures/fake_snyk_service_broker/config.ru
@@ -1,0 +1,24 @@
+require 'roda'
+
+class App < Roda
+  plugin :default_headers, 'Content-Type'=>'application/json'
+
+  route do |r|
+    r.on 'v2/catalog' do
+      open('catalog.json').read
+    end
+
+    r.on 'v2/service_instances', String do |name|
+      r.on 'service_bindings', String  do |sbid|
+        '{"credentials": {"apiToken":"snyk-secret-token"}}'
+      end
+
+      r.on do
+        '{"dashboard_url": "http://example.com"}'
+      end
+    end
+
+  end
+end
+
+run App.freeze.app

--- a/fixtures/fake_snyk_service_broker/manifest.yml
+++ b/fixtures/fake_snyk_service_broker/manifest.yml
@@ -1,0 +1,4 @@
+---
+applications:
+- name: fake_snyk_service_broker
+  buildpack: ruby_buildpack

--- a/fixtures/with_snyk/Procfile
+++ b/fixtures/with_snyk/Procfile
@@ -1,0 +1,1 @@
+web: node server.js

--- a/fixtures/with_snyk/manifest.yml
+++ b/fixtures/with_snyk/manifest.yml
@@ -1,0 +1,3 @@
+---
+applications:
+- name: snyk-app

--- a/fixtures/with_snyk/package.json
+++ b/fixtures/with_snyk/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "node_web_app",
+  "version": "0.0.0",
+  "description": "hello, world",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "express": "~4.15.2",
+    "logfmt": "~1.2.0",
+    "snyk": "latest"
+  },
+  "engines": {
+    "node": "~>6"
+  }
+}

--- a/fixtures/with_snyk/server.js
+++ b/fixtures/with_snyk/server.js
@@ -1,0 +1,15 @@
+// web.js
+var express = require("express");
+var logfmt = require("logfmt");
+var app = express();
+
+app.use(logfmt.requestLogger());
+
+app.get('/', function(req, res) {
+  res.send('Hello, World!');
+});
+
+var port = Number(process.env.PORT || 5000);
+app.listen(port, function() {
+  console.log("Listening on " + port);
+});

--- a/src/nodejs/hooks/snyk.go
+++ b/src/nodejs/hooks/snyk.go
@@ -21,6 +21,13 @@ type SnykHook struct {
 	buildDir    string
 	depsDir     string
 	localAgent  bool
+	orgName     string
+}
+
+type SnykCredentials struct {
+	ApiToken string
+	ApiUrl   string
+	OrgName  string
 }
 
 const snykLocalAgentPath = "node_modules/snyk/cli/index.js"
@@ -35,6 +42,7 @@ func init() {
 		buildDir:    "",
 		depsDir:     "",
 		localAgent:  true,
+		orgName:     "",
 	})
 }
 
@@ -47,17 +55,19 @@ func (h SnykHook) AfterCompile(stager *libbuildpack.Stager) error {
 	h.Log.Debug("Snyk token was found.")
 	h.Log.BeginStep("Checking if Snyk service is enabled...")
 
-	ignoreVulns := strings.ToLower(os.Getenv("SNYK_IGNORE_VULNS")) == "true"
+	dontBreakBuild := strings.ToLower(os.Getenv("SNYK_DONT_BREAK_BUILD")) == "true"
 	monitorBuild := strings.ToLower(os.Getenv("SNYK_MONITOR_BUILD")) == "true"
 	protectBuild := strings.ToLower(os.Getenv("SNYK_PROTECT_BUILD")) == "true"
+	orgName := strings.ToLower(os.Getenv("SNYK_ORG_NAME"))
 
-	h.Log.Debug("SNYK_IGNORE_VULNS is enabled: %t", ignoreVulns)
+	h.Log.Debug("SNYK_DONT_BREAK_BUILD is enabled: %t", dontBreakBuild)
 	h.Log.Debug("SNYK_MONITOR_BUILD is enabled: %t", monitorBuild)
 	h.Log.Debug("SNYK_PROTECT_BUILD is enabled: %t", protectBuild)
 
 	h.buildDir = stager.BuildDir()
 	h.depsDir = stager.DepDir()
 	h.localAgent = true
+	h.orgName = orgName
 
 	snykExists := h.isAgentExists()
 	if snykExists == false {
@@ -79,11 +89,11 @@ func (h SnykHook) AfterCompile(stager *libbuildpack.Stager) error {
 			return err
 		}
 
-		if !ignoreVulns {
+		if !dontBreakBuild {
 			h.Log.Error("Snyk found vulnerabilties. Failing build...")
 			return err
 		}
-		h.Log.Warning("SNYK_IGNORE_VULNS was defined, continue build despite vulnerabilities found")
+		h.Log.Warning("SNYK_DONT_BREAK_BUILD was defined, continue build despite vulnerabilities found")
 	}
 
 	if monitorBuild {
@@ -102,9 +112,15 @@ func (h SnykHook) isTokenExists() bool {
 		return true
 	}
 
-	token = h.getTokenFromCredentials()
-	if token != "" {
-		os.Setenv("SNYK_TOKEN", token)
+	status, snykCredentials := h.getCredentialsFromService()
+	if status {
+		os.Setenv("SNYK_TOKEN", snykCredentials.ApiToken)
+		if snykCredentials.ApiUrl != "" {
+			os.Setenv("SNYK_API", snykCredentials.ApiUrl)
+		}
+		if snykCredentials.OrgName != "" {
+			os.Setenv("SNYK_ORG_NAME", snykCredentials.OrgName)
+		}
 		return true
 	}
 	return false
@@ -134,6 +150,14 @@ func (h SnykHook) installAgent() error {
 }
 
 func (h SnykHook) runSnykCommand(args ...string) (string, error) {
+	if h.orgName != "" {
+		args = append(args, "--org="+h.orgName)
+	}
+
+	if os.Getenv("BP_DEBUG") != "" {
+		args = append(args, "-d")
+	}
+
 	// Snyk is part of the app modules.
 	if h.localAgent == true {
 		snykCliPath := filepath.Join(h.buildDir, snykLocalAgentPath)
@@ -148,23 +172,25 @@ func (h SnykHook) runSnykCommand(args ...string) (string, error) {
 
 func (h SnykHook) runTest() (bool, error) {
 	h.Log.Debug("Run Snyk test...")
-	output, err := h.runSnykCommand("test", "-d")
+	output, err := h.runSnykCommand("test")
 	if err == nil {
+		h.Log.Info("Snyk test finished successfully - %s", output)
 		return true, nil
 	}
 	//In case we got an unexpected output.
-	if !strings.Contains(output, "dependencies for known issues") {
+	if !strings.Contains(output, "dependencies for known") {
 		h.Log.Warning("Failed to run Snyk agent - %s", output)
 		h.Log.Warning("Please validate your auth token and that your npm version is equal or greater than v3.x.x")
 		return false, err
 	}
+	h.Log.Warning("Snyk found vulnerabilties - %s", output)
 	return true, err
 }
 
 func (h SnykHook) runMonitor() error {
 	h.Log.Debug("Run Snyk monitor...")
 	output, err := h.runSnykCommand("monitor", "--project-name="+h.appName())
-	h.Log.Debug("Snyk monitor %s", output)
+	h.Log.Info("Snyk monitor %s", output)
 	return err
 }
 
@@ -186,7 +212,16 @@ func (h SnykHook) runProtect() error {
 	return err
 }
 
-func (h SnykHook) getTokenFromCredentials() string {
+func getCredentialString(credentials map[string]interface{}, key string) string {
+	value, isString := credentials[key].(string)
+
+	if isString {
+		return value
+	}
+	return ""
+}
+
+func (h SnykHook) getCredentialsFromService() (bool, SnykCredentials) {
 	type Service struct {
 		Name        string                 `json:"name"`
 		Credentials map[string]interface{} `json:"credentials"`
@@ -195,20 +230,28 @@ func (h SnykHook) getTokenFromCredentials() string {
 	err := json.Unmarshal([]byte(os.Getenv("VCAP_SERVICES")), &vcapServices)
 	if err != nil {
 		h.Log.Warning("Failed to parse VCAP_SERVICES")
-		return ""
+		return false, SnykCredentials{}
 	}
 
-	for _, services := range vcapServices {
-		for _, service := range services {
-			if strings.Contains(service.Name, "snyk") {
-				if serviceToken, ok := service.Credentials["SNYK_TOKEN"]; ok {
-					return serviceToken.(string)
+	for key, services := range vcapServices {
+		if strings.Contains(key, "snyk") {
+			for _, service := range services {
+				apiToken := getCredentialString(service.Credentials, "apiToken")
+				if apiToken != "" {
+					apiUrl := getCredentialString(service.Credentials, "apiUrl")
+					orgName := getCredentialString(service.Credentials, "orgName")
+					snykCredantials := SnykCredentials{
+						ApiToken: apiToken,
+						ApiUrl:   apiUrl,
+						OrgName:  orgName,
+					}
+					return true, snykCredantials
 				}
 			}
 		}
 	}
 
-	return ""
+	return false, SnykCredentials{}
 }
 
 func (h SnykHook) appName() string {

--- a/src/nodejs/integration/nodejs_app_with_snyk_test.go
+++ b/src/nodejs/integration/nodejs_app_with_snyk_test.go
@@ -3,6 +3,7 @@ package integration_test
 import (
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/cloudfoundry/libbuildpack/cutlass"
 
@@ -11,43 +12,59 @@ import (
 )
 
 var _ = Describe("CF NodeJS Buildpack", func() {
-	var app *cutlass.App
-	var serviceName string
+	var app, sbApp *cutlass.App
+	var sbUrl string
 	RunCf := func(args ...string) error {
 		command := exec.Command("cf", args...)
 		command.Stdout = GinkgoWriter
 		command.Stderr = GinkgoWriter
 		return command.Run()
 	}
-	AfterEach(func() {
-		if app != nil {
-			app.Destroy()
-		}
-		app = nil
 
-		Expect(RunCf("delete-service", "-f", serviceName)).To(Succeed())
+	AfterEach(func() {
+		app = DestroyApp(app)
+
+		command := exec.Command("cf", "purge-service-offering", "-f", "snyk")
+		command.Stdout = GinkgoWriter
+		command.Stderr = GinkgoWriter
+		_ = command.Run()
+
+		command = exec.Command("cf", "delete-service-broker", "-f", "snyk")
+		command.Stdout = GinkgoWriter
+		command.Stderr = GinkgoWriter
+		_ = command.Run()
+
+		sbApp = DestroyApp(sbApp)
 	})
 
 	BeforeEach(func() {
-		app = cutlass.New(filepath.Join(bpDir, "fixtures", "logenv"))
+		sbApp = cutlass.New(filepath.Join(bpDir, "fixtures", "fake_snyk_service_broker"))
+		Expect(sbApp.Push()).To(Succeed())
+		Eventually(func() ([]string, error) { return sbApp.InstanceStates() }, 20*time.Second).Should(Equal([]string{"RUNNING"}))
+
+		var err error
+		sbUrl, err = sbApp.GetUrl("")
+		Expect(err).ToNot(HaveOccurred())
+
+		RunCf("create-service-broker", "snyk", "username", "password", sbUrl, "--space-scoped")
+		RunCf("create-service", "snyk", "public", "snyk")
+
+		app = cutlass.New(filepath.Join(bpDir, "fixtures", "with_snyk"))
 		app.SetEnv("BP_DEBUG", "true")
-
 		PushAppAndConfirm(app)
-
-		serviceName = "snyk-" + cutlass.RandStringRunes(20) + "-service"
 	})
 
-	Context("deploying a NodeJS app with Snyk service", func() {
+	Context("bind NodeJS app with snyk service", func() {
 		BeforeEach(func() {
-			Expect(RunCf("cups", serviceName, "-p", "'{\"SNYK_TOKEN\":\"secrettoken\"}'")).To(Succeed())
-			Expect(RunCf("bind-service", app.Name, serviceName)).To(Succeed())
+			RunCf("bind-service", app.Name, "snyk")
 
-			_ = RunCf("restage", app.Name)
+			app.Stdout.Reset()
+			RunCf("restage", app.Name)
 		})
 
 		It("test if Snyk token was found", func() {
 			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
-			Expect(app.Stdout.String()).To(ContainSubstring("Snyk token was found."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Snyk token was found"))
 		})
 	})
 })


### PR DESCRIPTION
This change adds support for custom api and organization to Snyk hook in order to be able to work offline.
In addition, Snyk hook now identifies the cradentials based on the service key instead of the name.
    
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
