### PR TITLE
remove extraneous escape

### DIFF
--- a/profile/appdynamics-setup.rb
+++ b/profile/appdynamics-setup.rb
@@ -28,6 +28,6 @@ if credentials
   if vcap['application_name']
     f.puts "export APPDYNAMICS_AGENT_APPLICATION_NAME=#{vcap['application_name']}"
     f.puts "export APPDYNAMICS_AGENT_TIER_NAME=#{vcap['application_name']}"
-    f.puts "export APPDYNAMICS_AGENT_NODE_NAME=#{vcap['application_name']}:\\$CF_INSTANCE_INDEX"
+    f.puts "export APPDYNAMICS_AGENT_NODE_NAME=#{vcap['application_name']}:\$CF_INSTANCE_INDEX"
   end
 end


### PR DESCRIPTION
Double-backslash `\\` will produce the literal string `$CF_INSTANCE_INDEX` instead of the instance index `0, 1, 2, etc.`

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
