### PR TITLE
remove extraneous escape

### DIFF
--- a/profile/appdynamics-setup.rb
+++ b/profile/appdynamics-setup.rb
@@ -28,6 +28,6 @@ if credentials
   if vcap['application_name']
     f.puts "export APPDYNAMICS_AGENT_APPLICATION_NAME=#{vcap['application_name']}"
     f.puts "export APPDYNAMICS_AGENT_TIER_NAME=#{vcap['application_name']}"
-    f.puts "export APPDYNAMICS_AGENT_NODE_NAME=#{vcap['application_name']}:\\$CF_INSTANCE_INDEX"
+    f.puts "export APPDYNAMICS_AGENT_NODE_NAME=#{vcap['application_name']}:\$CF_INSTANCE_INDEX"
   end
 end


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Double-backslash \\ will produce the literal string $CF_INSTANCE_INDEX instead of the instance index. This change will correctly substitute the instance index.

* An explanation of the use cases your change solves
In AppDynamics, the current expression resolves to the string `my-application:$CF_INSTANCE_INDEX`. All instances share this name. The goal is to have the instance name resolve to `my-application:0`, `my-application:1`, `my-application:2`, etc..

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
