### PR TITLE
fix parameter delivery in snyk hook

### DIFF
--- a/src/nodejs/hooks/snyk.go
+++ b/src/nodejs/hooks/snyk.go
@@ -186,7 +186,7 @@ func (h SnykHook) runSnykCommand(args ...string) (string, error) {
 	}
 
 	if h.severityThreshold != "" {
-		args = append(args, fmt.Sprintf(`--severity-threshold="%s"`, h.severityThreshold))
+		args = append(args, fmt.Sprintf(`--severity-threshold=%s`, h.severityThreshold))
 	}
 
 	// Snyk is part of the app modules.

--- a/src/nodejs/hooks/snyk_test.go
+++ b/src/nodejs/hooks/snyk_test.go
@@ -325,8 +325,8 @@ var _ = Describe("snykHook", func() {
 			It("should add severity threshold to command args", func() {
 				gomock.InOrder(
 					mockSnykCommand.EXPECT().Output(buildDir, "npm", "install", "-g", "snyk"),
-					mockSnykCommand.EXPECT().Output(buildDir, filepath.Join(depsDir, "node", "bin", "snyk"), "test", "-d", fmt.Sprintf(`--severity-threshold="%s"`, currentSeverityThreshold)),
-					mockSnykCommand.EXPECT().Output(buildDir, filepath.Join(depsDir, "node", "bin", "snyk"), "monitor", "--project-name=monitored_app", "-d", fmt.Sprintf(`--severity-threshold="%s"`, currentSeverityThreshold)),
+					mockSnykCommand.EXPECT().Output(buildDir, filepath.Join(depsDir, "node", "bin", "snyk"), "test", "-d", fmt.Sprintf(`--severity-threshold=%s`, currentSeverityThreshold)),
+					mockSnykCommand.EXPECT().Output(buildDir, filepath.Join(depsDir, "node", "bin", "snyk"), "monitor", "--project-name=monitored_app", "-d", fmt.Sprintf(`--severity-threshold=%s`, currentSeverityThreshold)),
 				)
 				err = snyk.AfterCompile(stager)
 				Expect(err).To(BeNil())


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
In snyk hook, there are extra `"` that surround the `--severity-threshold` parameter value, which make the value to be `"low"` instead of `low`, and the cli to fail. This PR removes them

* An explanation of the use cases your change solves

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
