### PR TITLE
Guarding the appdynamics baked-in buildpack with environment variable

### DIFF
--- a/profile/appdynamics-setup.rb
+++ b/profile/appdynamics-setup.rb
@@ -1,33 +1,35 @@
 #!/usr/bin/env ruby
-f = $stdout
-$stdout = open("/tmp/appdynamics-setup-profile.out.log", "w")
-$stderr.reopen("/tmp/appdynamics-setup-profile.err.log", "w")
-require 'json'
+if ENV["APPD_BUILDPACK"].nil? || ENV["APPD_BUILDPACK"]=="false"
+  f = $stdout
+  $stdout = open("/tmp/appdynamics-setup-profile.out.log", "w")
+  $stderr.reopen("/tmp/appdynamics-setup-profile.err.log", "w")
+  require 'json'
 
-vcap = JSON.load(ENV['VCAP_SERVICES']) rescue {}
-credentials = nil
+  vcap = JSON.load(ENV['VCAP_SERVICES']) rescue {}
+  credentials = nil
 
-offering_name = vcap.keys.select { |k| k =~ /app(\-)?dynamics/ }.first
-if offering_name
-  credentials = vcap.dig(offering_name, 0, 'credentials')
-elsif vcap['user-provided']
-  service = vcap['user-provided'].find do |service|
-    service['name'] =~ /app(\-)?dynamics/
+  offering_name = vcap.keys.select { |k| k =~ /app(\-)?dynamics/ }.first
+  if offering_name
+    credentials = vcap.dig(offering_name, 0, 'credentials')
+  elsif vcap['user-provided']
+    service = vcap['user-provided'].find do |service|
+      service['name'] =~ /app(\-)?dynamics/
+    end
+    credentials = service['credentials'] if service
   end
-  credentials = service['credentials'] if service
-end
 
-if credentials
-  f.puts "export APPDYNAMICS_CONTROLLER_HOST_NAME=#{credentials['host-name']}" if credentials['host-name']
-  f.puts "export APPDYNAMICS_CONTROLLER_PORT=#{credentials['port']}" if credentials['port']
-  f.puts "export APPDYNAMICS_AGENT_ACCOUNT_NAME=#{credentials['account-name']}" if credentials['account-name']
-  f.puts "export APPDYNAMICS_CONTROLLER_SSL_ENABLED=#{credentials['ssl-enabled']}" if credentials['ssl-enabled']
-  f.puts "export APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY=#{credentials['account-access-key']}" if credentials['account-access-key']
-
-  vcap = JSON.load(ENV['VCAP_APPLICATION']) rescue {}
-  if vcap['application_name']
-    f.puts "export APPDYNAMICS_AGENT_APPLICATION_NAME=#{vcap['application_name']}"
-    f.puts "export APPDYNAMICS_AGENT_TIER_NAME=#{vcap['application_name']}"
-    f.puts "export APPDYNAMICS_AGENT_NODE_NAME=#{vcap['application_name']}:\$CF_INSTANCE_INDEX"
+  if credentials
+    f.puts "export APPDYNAMICS_CONTROLLER_HOST_NAME=#{credentials['host-name']}" if credentials['host-name']
+    f.puts "export APPDYNAMICS_CONTROLLER_PORT=#{credentials['port']}" if credentials['port']
+    f.puts "export APPDYNAMICS_AGENT_ACCOUNT_NAME=#{credentials['account-name']}" if credentials['account-name']
+    f.puts "export APPDYNAMICS_CONTROLLER_SSL_ENABLED=#{credentials['ssl-enabled']}" if credentials['ssl-enabled']
+    f.puts "export APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY=#{credentials['account-access-key']}" if credentials['account-access-key']
+  
+    vcap = JSON.load(ENV['VCAP_APPLICATION']) rescue {}
+    if vcap['application_name']
+      f.puts "export APPDYNAMICS_AGENT_APPLICATION_NAME=#{vcap['application_name']}"
+      f.puts "export APPDYNAMICS_AGENT_TIER_NAME=#{vcap['application_name']}"
+      f.puts "export APPDYNAMICS_AGENT_NODE_NAME=#{vcap['application_name']}:\$CF_INSTANCE_INDEX"
+    end
   end
 end


### PR DESCRIPTION
We are moving forward with multi-buildpack installation for appdynamic language agents. As part of the exercise we are guarding support for language bundled buildpack. In this change we add environment variable guard to the file responsible for appdynamics node agent setup.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
Doesn't need one
