### PR TITLE
Remove AppDynamics integration logic totally from the buildpack and rely on extension buildpack solely

### DIFF
--- a/profile/appdynamics-setup.rb
+++ b/profile/appdynamics-setup.rb
@@ -1,35 +1,24 @@
 #!/usr/bin/env ruby
-if ENV["APPD_BUILDPACK"].nil? || ENV["APPD_BUILDPACK"]=="false"
-  f = $stdout
-  $stdout = open("/tmp/appdynamics-setup-profile.out.log", "w")
-  $stderr.reopen("/tmp/appdynamics-setup-profile.err.log", "w")
-  require 'json'
+f = $stdout
+$stdout = open("/tmp/appdynamics-setup-profile.out.log", "w")
+$stderr.reopen("/tmp/appdynamics-setup-profile.err.log", "w")
+require 'json'
 
-  vcap = JSON.load(ENV['VCAP_SERVICES']) rescue {}
-  credentials = nil
+vcap = JSON.load(ENV['VCAP_SERVICES']) rescue {}
+credentials = nil
 
-  offering_name = vcap.keys.select { |k| k =~ /app(\-)?dynamics/ }.first
-  if offering_name
-    credentials = vcap.dig(offering_name, 0, 'credentials')
-  elsif vcap['user-provided']
-    service = vcap['user-provided'].find do |service|
-      service['name'] =~ /app(\-)?dynamics/
-    end
-    credentials = service['credentials'] if service
+offering_name = vcap.keys.select { |k| k =~ /app(\-)?dynamics/ }.first
+if offering_name
+  credentials = vcap.dig(offering_name, 0, 'credentials')
+elsif vcap['user-provided']
+  service = vcap['user-provided'].find do |service|
+    service['name'] =~ /app(\-)?dynamics/
   end
+  credentials = service['credentials'] if service
+end
 
-  if credentials
-    f.puts "export APPDYNAMICS_CONTROLLER_HOST_NAME=#{credentials['host-name']}" if credentials['host-name']
-    f.puts "export APPDYNAMICS_CONTROLLER_PORT=#{credentials['port']}" if credentials['port']
-    f.puts "export APPDYNAMICS_AGENT_ACCOUNT_NAME=#{credentials['account-name']}" if credentials['account-name']
-    f.puts "export APPDYNAMICS_CONTROLLER_SSL_ENABLED=#{credentials['ssl-enabled']}" if credentials['ssl-enabled']
-    f.puts "export APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY=#{credentials['account-access-key']}" if credentials['account-access-key']
-  
-    vcap = JSON.load(ENV['VCAP_APPLICATION']) rescue {}
-    if vcap['application_name']
-      f.puts "export APPDYNAMICS_AGENT_APPLICATION_NAME=#{vcap['application_name']}"
-      f.puts "export APPDYNAMICS_AGENT_TIER_NAME=#{vcap['application_name']}"
-      f.puts "export APPDYNAMICS_AGENT_NODE_NAME=#{vcap['application_name']}:\$CF_INSTANCE_INDEX"
-    end
+if credentials 
+  if ENV["APPD_AGENT"].nil? || ENV["APPD_AGENT"]!= "nodejs"
+    f.puts " >&2 echo AppDynamics integration is now only suppoted via extension buildpack. Please refer https://docs.pivotal.io/partners/appdynamics/multibuildpack.html"
   end
 end


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves
Remove AppDynamics integration logic totally from the buildpack and rely on extension buildpack solely. An error message will now be printed when operator is trying to parse bound AppDynamics service without using extension builldpack.

* [ X] I have viewed signed and have submitted the Contributor License Agreement

* [ X] I have made this pull request to the `develop` branch

* [X ] I have added an integration test : Removal of feature, removed integration test 
