### PR TITLE
SKP-12673 use absolute path for importing Seeker instead of relative

### DIFF
--- a/fixtures/with_seeker/dist/server.js
+++ b/fixtures/with_seeker/dist/server.js
@@ -1,7 +1,7 @@
-var fs = require('fs')
-var express = require("express");
-var logfmt = require("logfmt");
-var app = express();
+const fs = require("fs")
+const express = require("express");
+const logfmt = require("logfmt");
+const app = express();
 
 app.use(logfmt.requestLogger());
 
@@ -11,6 +11,13 @@ app.get('/', function(req, res) {
 
 app.get('/config', function(req, res) {
   res.send('SEEKER_SERVER_URL: ' + process.env.SEEKER_SERVER_URL);
+});
+
+app.get('/self', function(req, res) {
+  fs.readFile(__filename, 'utf-8', (err, data) => {
+    if (err) throw err;
+    res.send(data);
+  });
 });
 
 var port = Number(process.env.PORT || 5000);

--- a/fixtures/with_seeker/package.json
+++ b/fixtures/with_seeker/package.json
@@ -2,9 +2,8 @@
   "name": "node_web_app",
   "version": "0.0.0",
   "description": "hello, world",
-  "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node ./dist/server.js"
   },
   "author": "",
   "license": "BSD-2-Clause",

--- a/src/nodejs/hooks/seeker_agent_test.go
+++ b/src/nodejs/hooks/seeker_agent_test.go
@@ -13,14 +13,15 @@ import (
 
 var _ = Describe("seekerHook", func() {
 	var (
-		err      error
-		buildDir string
-		depsDir  string
-		depsIdx  string
-		logger   *libbuildpack.Logger
-		stager   *libbuildpack.Stager
-		buffer   *bytes.Buffer
-		seeker   hooks.SeekerAfterCompileHook
+		err           error
+		buildDir      string
+		depsDir       string
+		depsIdx       string
+		logger        *libbuildpack.Logger
+		stager        *libbuildpack.Stager
+		buffer        *bytes.Buffer
+		seeker        hooks.SeekerAfterCompileHook
+		seekerRequire = hooks.SeekerRequire[:len(hooks.SeekerRequire)-1]
 	)
 
 	BeforeEach(func() {
@@ -55,75 +56,7 @@ var _ = Describe("seekerHook", func() {
 		Expect(err).NotTo(HaveOccurred())
 		os.RemoveAll(filepath.Join(os.TempDir(), "seeker_tmp"))
 	})
-	Describe("AfterCompile - obtain agent by directly downloading the agent", func() {
-		var (
-			oldVcapApplication string
-			oldVcapServices    string
-			oldBpDebug         string
-		)
-		BeforeEach(func() {
-			oldVcapApplication = os.Getenv("VCAP_APPLICATION")
-			oldVcapServices = os.Getenv("VCAP_SERVICES")
-			oldBpDebug = os.Getenv("BP_DEBUG")
-		})
-		AfterEach(func() {
 
-			os.Setenv("VCAP_APPLICATION", oldVcapApplication)
-			os.Setenv("VCAP_SERVICES", oldVcapServices)
-			os.Setenv("BP_DEBUG", oldBpDebug)
-		})
-
-		Context("VCAP_SERVICES contains seeker service - as a user provided service", func() {
-			BeforeEach(func() {
-				os.Setenv("VCAP_APPLICATION", `{"name":"pcf app"}`)
-				os.Setenv("VCAP_SERVICES", `{
-				 "user-provided": [
-				   {
-					 "name": "seeker_service_v2",
-					 "instance_name": "seeker_service_v2",
-					 "binding_name": null,
-					 "credentials": {
-						"seeker_server_url": "http://10.120.9.117:9911"
-					 },
-					 "syslog_drain_url": "",
-					 "volume_mounts": [],
-					 "label": "user-provided",
-					 "tags": []
-				   }
-				 ]
-				}`)
-			})
-		})
-		Context("VCAP_SERVICES contains seeker service - as a regular service", func() {
-			BeforeEach(func() {
-				os.Setenv("VCAP_APPLICATION", `{"name":"pcf app"}`)
-				os.Setenv("VCAP_SERVICES", `{
-					"seeker-security-service": [
-					 {
-					   "name": "seeker_instance",
-					   "instance_name": "seeker_instance",
-					   "binding_name": null,
-					   "credentials": {
-						"seeker_server_url": "http://10.120.9.117:9911"
-					   },
-					   "syslog_drain_url": null,
-					   "volume_mounts": [],
-					   "label": null,
-					   "provider": null,
-					   "plan": "default-seeker-plan-new",
-					   "tags": [
-						 "security",
-						 "agent",
-						 "monitoring"
-					   ]
-					 }
-					],
-					"2": [{"name":"mysql"}]}
-				`)
-			})
-		})
-
-	})
 	Describe("AfterCompile - adding agent require code to entry point", func() {
 		var (
 			oldVcapApplication string
@@ -162,7 +95,7 @@ var _ = Describe("seekerHook", func() {
 				  ]
 				 }`)
 			})
-			It("Prepends 'require('./seeker/node_modules/@synopsys-sig/seeker);' to the server.js file", func() {
+			It("prepends "+seekerRequire+" to the server.js file", func() {
 				entryPointPath := filepath.Join(buildDir, "server.js")
 				Expect(entryPointPath).ToNot(BeAnExistingFile())
 				const mockedCode = "some mock javascript code"
@@ -172,22 +105,22 @@ var _ = Describe("seekerHook", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(contents)).To(Equal(hooks.SeekerRequire + mockedCode))
 			})
-			It("does not prepend 'require('./seeker/node_modules/@synopsys-sig/seeker);' to the server.js file if it already exist", func() {
+			It("does not prepend "+seekerRequire+" to the server.js file if require already exist", func() {
 				entryPointPath := filepath.Join(buildDir, "server.js")
 				Expect(entryPointPath).ToNot(BeAnExistingFile())
 				const mockedCode = hooks.SeekerRequire + "some mock javascript code"
 				Expect(ioutil.WriteFile(entryPointPath, []byte(mockedCode), 0755)).To(Succeed())
+				seeker.PrependRequire(stager)
 				contents, err := ioutil.ReadFile(entryPointPath)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(contents)).To(Equal(mockedCode))
 			})
-			It("Fails to prepend the require to the server.js file - when the file does not exist", func() {
+			It("fails to prepend the "+seekerRequire+" to the server.js file in case the file does not exist", func() {
 				entryPointPath := filepath.Join(buildDir, "server.js")
 				Expect(entryPointPath).ToNot(BeAnExistingFile())
 				err = seeker.AfterCompile(stager)
 				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 			})
-
 		})
 	})
 })


### PR DESCRIPTION
When importing Seeker - use absolute path instead of relative.  This needed when an application has its server.js file not in the application root folder.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
