### PR TITLE
SKP-13739 create prefix folder before calling npm install

### DIFF
--- a/src/nodejs/hooks/seeker_agent.go
+++ b/src/nodejs/hooks/seeker_agent.go
@@ -152,6 +152,12 @@ func (h *SeekerAfterCompileHook) updateNodeModules(tgzPath string, appRoot strin
 	h.Log.Debug("About to install seeker agent, build dir: %s, seeker package: %s", appRoot, tgzPath)
 	var err error
 	const seekerModule = "seeker"
+	// create the seeker dir to workaround a known bug in npm 7
+	seekerModulePath := filepath.Join(appRoot, seekerModule)
+	err = os.Mkdir(seekerModulePath, 0755)
+	if err != nil {
+		h.Log.Debug("Failed to create seeker folder in: %s. Error: %s", seekerModulePath, err.Error())
+	}
 	if os.Getenv("BP_DEBUG") != "" {
 		err = h.Command.Execute(appRoot, os.Stdout, os.Stderr, "npm", "install", "--save", tgzPath, "--prefix", seekerModule)
 	} else {


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This patch is required to workaround a known issue in npm 7 (was fixed in 7.4).

* An explanation of the use cases your change solves
See: https://github.com/npm/cli/issues/2012

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
