### PR TITLE
Adding error information when npm install phase fails

### DIFF
--- a/src/nodejs/supply/supply.go
+++ b/src/nodejs/supply/supply.go
@@ -702,6 +702,7 @@ func nodeVersionRequiresSSLEnvVars(version string) (bool, error) {
 func (s *Supplier) InstallNPM() error {
 	buffer := new(bytes.Buffer)
 	if err := s.Command.Execute(s.Stager.BuildDir(), buffer, buffer, "npm", "--version"); err != nil {
+		s.Log.Error(strings.TrimSuffix(strings.TrimSpace(buffer.String()), "\n"))
 		return err
 	}
 


### PR DESCRIPTION
This change is to add some error logs when the npm install phase fails.
This is in reponse to my own issue I created #521 
This helped me solve the issue I was scratching my head about for half a day.