### PR TITLE
Don't run `yarn check` which creates a duplicate cache

### DIFF
--- a/src/nodejs/integration/yarn_test.go
+++ b/src/nodejs/integration/yarn_test.go
@@ -73,15 +73,6 @@ func testYarn(platform switchblade.Platform, fixtures string) func(*testing.T, s
 
 				Expect(os.WriteFile(filepath.Join(source, "package.json"), content, 0600)).To(Succeed())
 			})
-
-			it("warns that yarn.lock is out of date", func() {
-				_, logs, err := platform.Deploy.Execute(name, source)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(logs).To(ContainLines(
-					ContainSubstring("yarn.lock is outdated"),
-				))
-			})
 		})
 
 		context("when there are unmet dependencies", func() {

--- a/src/nodejs/supply/supply.go
+++ b/src/nodejs/supply/supply.go
@@ -83,10 +83,9 @@ type Supplier struct {
 }
 
 var LTS = map[string]int{
-	"argon":   4,
-	"boron":   6,
-	"carbon":  8,
-	"dubnium": 10,
+	"fermium":  14,
+	"gallium":  16,
+	"hydrogen": 18,
 }
 
 func Run(s *Supplier) error {

--- a/src/nodejs/supply/supply_test.go
+++ b/src/nodejs/supply/supply_test.go
@@ -279,11 +279,10 @@ var _ = Describe("Supply", func() {
 				defer os.Remove(nvmrcFile)
 
 				testCases := [][]string{
-					{"lts/*", "10.*.*"},
-					{"lts/argon", "4.*.*"},
-					{"lts/boron", "6.*.*"},
-					{"lts/carbon", "8.*.*"},
-					{"lts/dubnium", "10.*.*"},
+					{"lts/fermium", "14.*.*"},
+					{"lts/gallium", "16.*.*"},
+					{"lts/hydrogen", "18.*.*"},
+					{"lts/*", "18.*.*"},
 				}
 
 				for _, testCase := range testCases {
@@ -438,7 +437,7 @@ var _ = Describe("Supply", func() {
 
 		Context("given valid .nvmrc", func() {
 			It("validate should succeed", func() {
-				validVersions := []string{"11.4", "node", "lts/*", "lts/carbon", "10", "10.1.1"}
+				validVersions := []string{"11.4", "node", "lts/*", "lts/hydrogen", "10", "10.1.1"}
 				for _, version := range validVersions {
 					Expect(os.WriteFile(filepath.Join(buildDir, ".nvmrc"), []byte(version), 0777)).To(Succeed())
 					Expect(supplier.LoadNvmrc()).To(Succeed())

--- a/src/nodejs/yarn/yarn.go
+++ b/src/nodejs/yarn/yarn.go
@@ -27,8 +27,7 @@ func (y *Yarn) Build(buildDir, cacheDir string) error {
 		return err
 	}
 
-	installArgs := []string{"install", "--pure-lockfile", "--ignore-engines", "--cache-folder", filepath.Join(cacheDir, ".cache/yarn")}
-	checkArgs := []string{"check"}
+	installArgs := []string{"install", "--pure-lockfile", "--ignore-engines", "--cache-folder", filepath.Join(cacheDir, ".cache/yarn"), "--check-files"}
 
 	yarnConfig := map[string]string{}
 	if offline {
@@ -37,7 +36,6 @@ func (y *Yarn) Build(buildDir, cacheDir string) error {
 		y.Log.Info("Running yarn in offline mode")
 
 		installArgs = append(installArgs, "--offline")
-		checkArgs = append(checkArgs, "--offline")
 
 		yarnConfig["yarn-offline-mirror"] = yarnOfflineMirror
 		yarnConfig["yarn-offline-mirror-pruning"] = "false"
@@ -68,13 +66,9 @@ func (y *Yarn) Build(buildDir, cacheDir string) error {
 		return err
 	}
 
-	if err := y.Command.Execute(buildDir, io.Discard, os.Stderr, "yarn", checkArgs...); err != nil {
-		if _, ok := err.(*exec.ExitError); !ok {
-			return err
-		}
-		y.Log.Warning("yarn.lock is outdated")
-	} else {
-		y.Log.Info("yarn.lock and package.json match")
+	err = os.RemoveAll(filepath.Join(buildDir, "npm-packages-offline-cache"))
+	if err != nil {
+		panic(err)
 	}
 
 	return nil


### PR DESCRIPTION
* A short explanation of the proposed change:
The buildpack runs 2 `yarn` commands: `yarn install` and `yarn check`. The `yarn install` command is configured to ensure that the cache ends up in the right place on the filesystem, but the `yarn check` command is not configured with that same setting and will force a new cache to be created at the default location of `$HOME/.yarn-cache`. When investigating the `yarn check` command, it was documented that we migrate to specifying the `--check-files` flag on the `yarn install` command instead of using `yarn check`. This PR removes the use of the `yarn check` command and adds the `--check-files` flag to the `yarn install` command as directed.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have added an integration test
