### PR TITLE
profile script: do not overwrite std files

### DIFF
--- a/profile/appdynamics-setup.sh
+++ b/profile/appdynamics-setup.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-exec 1>> /tmp/appdynamics-setup-profile.out.log
-exec 2>> /tmp/appdynamics-setup-profile.err.log
+logfile="/tmp/appdynamics-setup-profile.out.log"
 
 if [ -n "${APPD_AGENT}" ]; then
-  echo "Exiting. APPD_AGENT variable not set"
+  echo "Exiting. APPD_AGENT variable not set" >> "${logfile}"
   exit 0
 fi
 
@@ -12,7 +11,7 @@ service="$(echo "${VCAP_SERVICES}" | jq -r '[.[][] | select(.name | match("app(-
 credentials=$(echo "${service}" | jq -r '.[0].credentials')
 
 if [ -z "${credentials}" ]; then
-  echo "Exiting. credentials not found in VCAP_SERVICES"
+  echo "Exiting. credentials not found in VCAP_SERVICES" >> "${logfile}"
   exit 0
 fi
 


### PR DESCRIPTION
This is a follow-up to #605

.profile.d scripts are "sourced" by the lifecycle one after the other, so make sure stdout/err for subsequent scripts are unaffected.

Fixes brats tests @ https://buildpacks.ci.cf-app.com/teams/main/pipelines/nodejs-buildpack/jobs/specs-edge-brats-develop/builds/1031
