### PR TITLE
Deprecate Nodejs v14.x (EOL)

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,10 +24,6 @@ include_files:
 - profile/newrelic-setup.sh
 - profile/nodejs.sh
 dependency_deprecation_dates:
-- version_line: 14.x.x
-  name: node
-  date: 2023-04-30
-  link: https://github.com/nodejs/Release
 - version_line: 16.x.x
   name: node
   date: 2023-09-11
@@ -37,38 +33,6 @@ dependency_deprecation_dates:
   date: 2025-04-30
   link: https://github.com/nodejs/Release
 dependencies:
-- name: node
-  version: 14.21.2
-  uri: https://buildpacks.cloudfoundry.org/dependencies/node/node_14.21.2_linux_x64_cflinuxfs3_ef7ab2a4.tgz
-  sha256: ef7ab2a4e6862e6d04ecb28cc2573d601fad5c250899adf771859046de258e5e
-  cf_stacks:
-  - cflinuxfs3
-  source: https://nodejs.org/dist/v14.21.2/node-v14.21.2.tar.gz
-  source_sha256: aad2b8ac4808a069648caf0dcc938a7a01265c1efcdeb7329a7cc9474f2b87eb
-- name: node
-  version: 14.21.2
-  uri: https://buildpacks.cloudfoundry.org/dependencies/node/node_14.21.2_linux_x64_cflinuxfs4_66777e33.tgz
-  sha256: 66777e3327340e7ab4cda7778eeff555d1c70ef94ac5239e09f4aaf65356c792
-  cf_stacks:
-  - cflinuxfs4
-  source: https://nodejs.org/dist/v14.21.2/node-v14.21.2.tar.gz
-  source_sha256: aad2b8ac4808a069648caf0dcc938a7a01265c1efcdeb7329a7cc9474f2b87eb
-- name: node
-  version: 14.21.3
-  uri: https://buildpacks.cloudfoundry.org/dependencies/node/node_14.21.3_linux_x64_cflinuxfs3_899d3362.tgz
-  sha256: 899d3362422b2c6bbabd714e7dd58e2552e019b184597429944c23d29655fff0
-  cf_stacks:
-  - cflinuxfs3
-  source: https://nodejs.org/dist/v14.21.3/node-v14.21.3.tar.gz
-  source_sha256: 97eb4c0ea1ffb73eb0486db5125e5351f744e65df6b3d10fbc0611dec7fd27cb
-- name: node
-  version: 14.21.3
-  uri: https://buildpacks.cloudfoundry.org/dependencies/node/node_14.21.3_linux_x64_cflinuxfs4_7efadd52.tgz
-  sha256: 7efadd527e2540552703c1afcda23f004f5746b9d233ba2cf464b046a82ad169
-  cf_stacks:
-  - cflinuxfs4
-  source: https://nodejs.org/dist/v14.21.3/node-v14.21.3.tar.gz
-  source_sha256: 97eb4c0ea1ffb73eb0486db5125e5351f744e65df6b3d10fbc0611dec7fd27cb
 - name: node
   version: 16.19.1
   uri: https://buildpacks.cloudfoundry.org/dependencies/node/node_16.19.1_linux_x64_cflinuxfs3_8cd43ab9.tgz

--- a/src/nodejs/integration/versions_test.go
+++ b/src/nodejs/integration/versions_test.go
@@ -41,7 +41,7 @@ func testVersions(platform switchblade.Platform, fixtures string) func(*testing.
 
 		context("when there is a .nvmrc file", func() {
 			it.Before(func() {
-				Expect(os.WriteFile(filepath.Join(source, ".nvmrc"), []byte("14"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(source, ".nvmrc"), []byte("16"), 0600)).To(Succeed())
 			})
 
 			it("uses the Node version specified in the .nvmrc file", func() {
@@ -49,7 +49,7 @@ func testVersions(platform switchblade.Platform, fixtures string) func(*testing.
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(logs).To(ContainLines(
-					MatchRegexp("Installing node 14\\.\\d+\\.\\d+"),
+					MatchRegexp("Installing node 16\\.\\d+\\.\\d+"),
 				))
 
 				Eventually(deployment).Should(Serve("Hello world!"))
@@ -63,7 +63,7 @@ func testVersions(platform switchblade.Platform, fixtures string) func(*testing.
 				}
 				Expect(json.NewDecoder(response.Body).Decode(&process)).To(Succeed())
 
-				Expect(process.Version).To(MatchRegexp(`v14\.\d+\.\d+`))
+				Expect(process.Version).To(MatchRegexp(`v16\.\d+\.\d+`))
 			})
 		})
 
@@ -76,7 +76,7 @@ func testVersions(platform switchblade.Platform, fixtures string) func(*testing.
 				Expect(json.NewDecoder(file).Decode(&pkg)).To(Succeed())
 				Expect(file.Close()).To(Succeed())
 
-				pkg["engines"] = map[string]string{"node": "~>14"}
+				pkg["engines"] = map[string]string{"node": "~>16"}
 				content, err := json.Marshal(pkg)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.WriteFile(filepath.Join(source, "package.json"), content, 0600)).To(Succeed())
@@ -87,7 +87,7 @@ func testVersions(platform switchblade.Platform, fixtures string) func(*testing.
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(logs).To(ContainLines(
-					MatchRegexp("Installing node 14\\.\\d+\\.\\d+"),
+					MatchRegexp("Installing node 16\\.\\d+\\.\\d+"),
 				))
 
 				Eventually(deployment).Should(Serve("Hello world!"))
@@ -101,7 +101,7 @@ func testVersions(platform switchblade.Platform, fixtures string) func(*testing.
 				}
 				Expect(json.NewDecoder(response.Body).Decode(&process)).To(Succeed())
 
-				Expect(process.Version).To(MatchRegexp(`v14\.\d+\.\d+`))
+				Expect(process.Version).To(MatchRegexp(`v16\.\d+\.\d+`))
 			})
 
 			context("when that version is unsupported", func() {

--- a/src/nodejs/supply/supply.go
+++ b/src/nodejs/supply/supply.go
@@ -83,7 +83,6 @@ type Supplier struct {
 }
 
 var LTS = map[string]int{
-	"fermium":  14,
 	"gallium":  16,
 	"hydrogen": 18,
 }

--- a/src/nodejs/supply/supply_test.go
+++ b/src/nodejs/supply/supply_test.go
@@ -279,6 +279,7 @@ var _ = Describe("Supply", func() {
 				defer os.Remove(nvmrcFile)
 
 				testCases := [][]string{
+					{"lts/gallium", "16.*.*"},
 					{"lts/hydrogen", "18.*.*"},
 					{"lts/*", "18.*.*"},
 				}

--- a/src/nodejs/supply/supply_test.go
+++ b/src/nodejs/supply/supply_test.go
@@ -279,8 +279,6 @@ var _ = Describe("Supply", func() {
 				defer os.Remove(nvmrcFile)
 
 				testCases := [][]string{
-					{"lts/fermium", "14.*.*"},
-					{"lts/gallium", "16.*.*"},
 					{"lts/hydrogen", "18.*.*"},
 					{"lts/*", "18.*.*"},
 				}


### PR DESCRIPTION
Part of #601.

Ref: https://nodejs.dev/en/about/releases/