### PR TITLE
Update npm version in tests

### DIFF
--- a/src/nodejs/integration/npm_test.go
+++ b/src/nodejs/integration/npm_test.go
@@ -71,7 +71,7 @@ func testNPM(platform switchblade.Platform, fixtures string) func(*testing.T, sp
 				Expect(json.NewDecoder(file).Decode(&pkg)).To(Succeed())
 				Expect(file.Close()).To(Succeed())
 
-				pkg["engines"] = map[string]string{"npm": "^7"}
+				pkg["engines"] = map[string]string{"npm": "^8"}
 				content, err := json.Marshal(pkg)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.WriteFile(filepath.Join(source, "package.json"), content, 0600)).To(Succeed())
@@ -89,8 +89,8 @@ func testNPM(platform switchblade.Platform, fixtures string) func(*testing.T, sp
 				Eventually(deployment).Should(Serve("Hello, World!"))
 
 				Expect(logs.String()).To(SatisfyAll(
-					ContainSubstring("engines.npm (package.json): ^7"),
-					ContainSubstring("Downloading and installing npm ^7"),
+					ContainSubstring("engines.npm (package.json): ^8"),
+					ContainSubstring("Downloading and installing npm ^8"),
 				))
 			})
 		})


### PR DESCRIPTION
# Context
When we updated the Python version that this Buildpack uses in #641, a new error came out on the CI. After some workaround, I found that there is an incompatibility between `node-gyp` and `python3.11` when you are trying to build native modules using NPM `<=7`.

NPM is not going to fix this behavior as seen in https://github.com/mmomtchev/pymport/issues/19 (an example of a native module getting errors when using npm6 and Python 3.11) because it's an old/deprecated NPM version (associated with Node `14.x`, deprecated some time ago in #608)

This is fixed using NPM `>=8`

```bash
2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! Traceback (most recent call last):
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py", line 51, in <module>
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     sys.exit(gyp.script_main())
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!              ^^^^^^^^^^^^^^^^^
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 670, in script_main
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     return main(sys.argv[1:])
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!            ^^^^^^^^^^^^^^^^^^
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 662, in main
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     return gyp_main(args)
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!            ^^^^^^^^^^^^^^
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 629, in gyp_main
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     [generator, flat_list, targets, data] = Load(
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!                                             ^^^^^
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 150, in Load
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     result = gyp.input.Load(
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!              ^^^^^^^^^^^^^^^
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 3021, in Load
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     LoadTargetBuildFile(
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 411, in LoadTargetBuildFile
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     build_file_data = LoadOneBuildFile(
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!                       ^^^^^^^^^^^^^^^^^
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!   File "/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 239, in LoadOneBuildFile
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!     build_file_contents = open(build_file_path, "rU").read()
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR!                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! ValueError: invalid mode: 'rU' while trying to load binding.gyp
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! gyp ERR! configure error
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! gyp ERR! stack Error: `gyp` failed with exit code: 1
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! gyp ERR! stack     at ChildProcess.onCpExit (/tmp/contents395280350/deps/0/node/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:351:16)
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:514:28)
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:291:12)
   2023-08-30T14:38:19.81-0400 [STG/0] OUT npm ERR! gyp ERR! System Linux 5.19.0-41-generic
```

# Solution

Since the test is checking the behavior of Node when installing a specific version of NPM, and taking into account that the default version of the buildpack is 18.x I changed the tests to install NPM 8 (default version of 16.x) which does not present problems with the above-mentioned node-gyp behavior and follows the test purpose.