### PR TITLE
profile script: do not run exit command

### DIFF
--- a/profile/appdynamics-setup.sh
+++ b/profile/appdynamics-setup.sh
@@ -1,57 +1,49 @@
 #!/bin/sh
 
-logfile="/tmp/appdynamics-setup-profile.out.log"
+if [ -z "${APPD_AGENT}" ]; then
+  service="$(echo "${VCAP_SERVICES}" | jq -r '[.[][] | select(.name | match("app(-)?dynamics"))]')"
+  credentials=$(echo "${service}" | jq -r '.[0].credentials')
 
-if [ -n "${APPD_AGENT}" ]; then
-  echo "Exiting. APPD_AGENT variable not set" >> "${logfile}"
-  exit 0
-fi
+  if [ -n "${credentials}" ] && [ "${credentials}" != "null" ]; then
+    controller_host=$(echo "${credentials}" | jq -r '.["host-name"]')
+    controller_port=$(echo "${credentials}" | jq -r '.port')
+    account_name=$(echo "${credentials}" | jq -r '.["account-name"]')
+    ssl_enabled=$(echo "${credentials}" | jq -r '.["ssl-enabled"]')
+    account_access_key=$(echo "${credentials}" | jq -r '.["account-access-key"]')
 
-service="$(echo "${VCAP_SERVICES}" | jq -r '[.[][] | select(.name | match("app(-)?dynamics"))]')"
-credentials=$(echo "${service}" | jq -r '.[0].credentials')
+    if [ -n "${controller_host}" ]; then
+      export APPDYNAMICS_CONTROLLER_HOST_NAME="${controller_host}"
+    fi
 
-if [ -z "${credentials}" ]; then
-  echo "Exiting. credentials not found in VCAP_SERVICES" >> "${logfile}"
-  exit 0
-fi
+    if [ -n "${controller_port}" ]; then
+      export APPDYNAMICS_CONTROLLER_PORT="${controller_port}"
+    fi
 
-controller_host=$(echo "${credentials}" | jq -r '.["host-name"]')
-controller_port=$(echo "${credentials}" | jq -r '.port')
-account_name=$(echo "${credentials}" | jq -r '.["account-name"]')
-ssl_enabled=$(echo "${credentials}" | jq -r '.["ssl-enabled"]')
-account_access_key=$(echo "${credentials}" | jq -r '.["account-access-key"]')
+    if [ -n "${account_name}" ]; then
+      export APPDYNAMICS_AGENT_ACCOUNT_NAME="${account_name}"
+    fi
 
-if [ -n "${controller_host}" ]; then
-  export APPDYNAMICS_CONTROLLER_HOST_NAME="${controller_host}"
-fi
+    if [ -n "${ssl_enabled}" ]; then
+      export APPDYNAMICS_CONTROLLER_SSL_ENABLED="${ssl_enabled}"
+    fi
 
-if [ -n "${controller_port}" ]; then
-  export APPDYNAMICS_CONTROLLER_PORT="${controller_port}"
-fi
+    if [ -n "${account_access_key}" ]; then
+      export APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY="${account_access_key}"
+    fi
 
-if [ -n "${account_name}" ]; then
-  export APPDYNAMICS_AGENT_ACCOUNT_NAME="${account_name}"
-fi
+    application_name=$(echo "${VCAP_APPLICATION}" | jq -r '.application_name')
+    if [ -z "${application_name}" ]; then
+      exit 0
+    fi
 
-if [ -n "${ssl_enabled}" ]; then
-  export APPDYNAMICS_CONTROLLER_SSL_ENABLED="${ssl_enabled}"
-fi
-
-if [ -n "${account_access_key}" ]; then
-  export APPDYNAMICS_AGENT_ACCOUNT_ACCESS_KEY="${account_access_key}"
-fi
-
-application_name=$(echo "${VCAP_APPLICATION}" | jq -r '.application_name')
-if [ -z "${application_name}" ]; then
-  exit 0
-fi
-
-if [ -z "${APPDYNAMICS_AGENT_APPLICATION_NAME}" ]; then
-  export APPDYNAMICS_AGENT_APPLICATION_NAME="${application_name}"
-fi
-if [ -z "${APPDYNAMICS_AGENT_TIER_NAME}" ]; then
-  export APPDYNAMICS_AGENT_TIER_NAME="${application_name}"
-fi
-if [ -z "${APPDYNAMICS_AGENT_NODE_NAME}" ]; then
-  export APPDYNAMICS_AGENT_NODE_NAME="${application_name}:${CF_INSTANCE_INDEX}"
+    if [ -z "${APPDYNAMICS_AGENT_APPLICATION_NAME}" ]; then
+      export APPDYNAMICS_AGENT_APPLICATION_NAME="${application_name}"
+    fi
+    if [ -z "${APPDYNAMICS_AGENT_TIER_NAME}" ]; then
+      export APPDYNAMICS_AGENT_TIER_NAME="${application_name}"
+    fi
+    if [ -z "${APPDYNAMICS_AGENT_NODE_NAME}" ]; then
+      export APPDYNAMICS_AGENT_NODE_NAME="${application_name}:${CF_INSTANCE_INDEX}"
+    fi
+  fi
 fi


### PR DESCRIPTION
It looks like lifecycle `source`s profile scripts, and therefore an `exit` statement in the script stops the entire process starting the app.

The error in the script only surfaces when `$APPD_AGENT` is set by the user. The original PR submitted by appdynamics contributor[1] suggests that the variable` $APPD_AGENT` is set by the user to signal a Multibuildpack setup. This is when users explicitly use a dedicated appdyanmics buildpack, and in that case, buildpacks like CF nodejs buildpack do not set up appdyanmics and instead leaves it to the appdyanmics buildpack. Looking for an example of such a buildpack, the documentation of the proprietary tanzu appdynamics buildpack supports this[2].

To reproduce the error:
cf push testapp -p fixtures/simple --no-start
cf set-env testapp APPD_AGENT "something"
cf restage testapp

---
1. https://github.com/cloudfoundry/nodejs-buildpack/pull/214
2. https://docs.vmware.com/en/AppDynamics-Application-Performance-Monitoring-for-VMware-Tanzu/services/appdynamics-application-performance-monitoring/using.html#nodejs-applications-multibuildpack-10
