### PR TITLE
Add option --retry-all-errors when downloading go version

### DIFF
--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -29,6 +29,7 @@ function main() {
       --silent \
       --location \
       --retry 15 \
+      --retry-all-errors \
       --retry-delay 2 \
       --output "/tmp/go.tgz"
 


### PR DESCRIPTION
Add option --retry-all-errors when downloading go version

* A short explanation of the proposed change: 
Adding option --retry-all-errors to the curl command used to download the go binary

* An explanation of the use cases your change solves
Using just the --retry option of curl doesn't make the call stable enough as it would fail to retry in cases of 'Connection reset by peer' when there's an TCP/IP issue while trying to connect to the host, for example. Adding --retry-all-errors option to the --retry [x], would cause retry of the call, no matter what the responce error is. In this concrete case, as the called url is well known (https://buildpacks.cloudfoundry.org/dependencies/go), adding --retry-all-errors would make the call even more resilient.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
