### PR TITLE
ci: update github action versions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Fetch Pull Request Details
         id: pull_request

--- a/.github/workflows/dependency-deprecation-reminder.yml
+++ b/.github/workflows/dependency-deprecation-reminder.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: develop
 

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -16,7 +16,7 @@ jobs:
           echo "month=$(date +%b)" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CF_BOT_GITHUB_TOKEN }}
           ref: develop

--- a/.github/workflows/synchronize-labels.yml
+++ b/.github/workflows/synchronize-labels.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on:
       - ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: micnncim/action-label-syncer@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
 
@@ -32,7 +32,7 @@ jobs:
     needs: unit
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set Matrix
         id: set-matrix
@@ -51,12 +51,12 @@ jobs:
     steps:
 
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19.x
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
 
@@ -112,7 +112,7 @@ jobs:
 
       - name: Checkout
         if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/update-github-config.yml
+++ b/.github/workflows/update-github-config.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CF_BOT_GITHUB_TOKEN }}
           ref: develop
 
       - name: Checkout github-config
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: cloudfoundry/buildpacks-github-config
           path: github-config


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Working on my other PR (#679) I noticed the `actions/checkout` and `actions/setup-go` this repository uses are using older version. This PR updates them.

* An explanation of the use cases your change solves

N.A.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] (N.A.) ~~I have made this pull request to the `develop` branch~~

* [x] (N.A.) ~~I have added an integration test~~
