### PR TITLE
Add new parameters for sealights hook

### DIFF
--- a/src/nodejs/hooks/sealights_test.go
+++ b/src/nodejs/hooks/sealights_test.go
@@ -69,10 +69,12 @@ var _ = Describe("Sealights hook", func() {
 		projectRoot = os.Getenv("SL_PROJECT_ROOT")
 		testStage = os.Getenv("SL_TEST_STAGE")
 		command = &Command{}
+		parameters := &hooks.SealightsParameters{}
 		sealights = &hooks.SealightsHook{
 			libbuildpack.DefaultHook{},
 			logger,
 			command,
+			parameters,
 		}
 	})
 


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
I have update sealight build hook to support installing of specific version

* An explanation of the use cases your change solves
User can set extra parameters in sealights user-provided services as `version` and `customAgentUrl`
Also recomended version from sealight server can be requested if `SL_DOMAIN` was provided

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
