### PR TITLE
fix: npm version invalid value if log level is not the default

### DIFF
--- a/src/nodejs/supply/supply.go
+++ b/src/nodejs/supply/supply.go
@@ -741,7 +741,7 @@ func nodeVersionRequiresSSLEnvVars(version string) (bool, error) {
 
 func (s *Supplier) InstallNPM() error {
 	buffer := new(bytes.Buffer)
-	if err := s.Command.Execute(s.Stager.BuildDir(), buffer, buffer, "npm", "--version"); err != nil {
+	if err := s.Command.Execute(s.Stager.BuildDir(), buffer, buffer, "npm", "--version", "--logelevel", "notice"); err != nil {
 		s.Log.Error(strings.TrimSuffix(strings.TrimSpace(buffer.String()), "\n"))
 		return err
 	}


### PR DESCRIPTION
The assumption for the command `npm --version` is
that the loglevel is the default (`notice`) but depending on the [npm config](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc) it could be set to a different log level which makes the output  (stored in variable `npmVersion`) invalid.