### PR TITLE
fix: npm version command

### DIFF
--- a/src/nodejs/supply/supply.go
+++ b/src/nodejs/supply/supply.go
@@ -741,7 +741,7 @@ func nodeVersionRequiresSSLEnvVars(version string) (bool, error) {
 
 func (s *Supplier) InstallNPM() error {
 	buffer := new(bytes.Buffer)
-	if err := s.Command.Execute(s.Stager.BuildDir(), buffer, buffer, "npm", "--version"); err != nil {
+	if err := s.Command.Execute(s.Stager.BuildDir(), buffer, buffer, "npm", "--version", "--loglevel", "notice"); err != nil {
 		s.Log.Error(strings.TrimSuffix(strings.TrimSpace(buffer.String()), "\n"))
 		return err
 	}


### PR DESCRIPTION
# Problem
In my environment, the npm version was not received, since the [global log level was set to verbose](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#files).

the variable `npmVersion `contained then the value `npm verb cli F:\apps\Node.s\....`

# Solution

When using the `npm --version` command the assumption is, that the loglevel is set to the default, because the output is "parsed" to the version

The loglevel config option can be configured globally such that the output cannot be "parsed" anymore to the version.

Hence this change uses the explicit loglevel required for "parsing" the version

# Checks

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] (N/A) ~~I have added an integration test~~
