### PR TITLE
Remove dependency credential test

### DIFF
--- a/src/nodejs/brats/brats_test.go
+++ b/src/nodejs/brats/brats_test.go
@@ -11,7 +11,6 @@ var _ = Describe("Nodejs buildpack", func() {
 	bratshelper.UnbuiltBuildpack("node", CopyBrats)
 	bratshelper.DeployingAnAppWithAnUpdatedVersionOfTheSameBuildpack(CopyBrats)
 	bratshelper.StagingWithBuildpackThatSetsEOL("node", CopyBrats)
-	bratshelper.StagingWithCustomBuildpackWithCredentialsInDependencies(CopyBrats)
 	bratshelper.DeployAppWithExecutableProfileScript("node", CopyBrats)
 	bratshelper.DeployAnAppWithSensitiveEnvironmentVariables(CopyBrats)
 	bratshelper.ForAllSupportedVersions("node", CopyBrats, func(nodeVersion string, app *cutlass.App) {


### PR DESCRIPTION
- the change in CDN results in these tests failing, because the new CDN config does not support credentials in this way.
- we believe that consumers do not use this feature, as we have not had any reports of this causing failures for consumers.
- if we get reports that consumers cannot download dependencies from the CDN with credentials, and we deem this to be a necessary feature, we can update the CDN config and re-add these tests.
