### PR TITLE
bumps libbuildpack-dynatrace to v1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudfoundry/nodejs-buildpack
 go 1.22.5
 
 require (
-	github.com/Dynatrace/libbuildpack-dynatrace v1.5.2
+	github.com/Dynatrace/libbuildpack-dynatrace v1.8.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/cloudfoundry/libbuildpack v0.0.0-20240717165421-f2ae8069fcba
 	github.com/cloudfoundry/switchblade v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/CycloneDX/cyclonedx-go v0.7.1/go.mod h1:N/nrdWQI2SIjaACyyDs/u7+ddCkyl/zkNs8xFsHF2Ps=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/Dynatrace/libbuildpack-dynatrace v1.5.2 h1:yiF8yuJ4762ocmZEM+/K8auciKFQ3XfQb/0Qt7VL+rU=
-github.com/Dynatrace/libbuildpack-dynatrace v1.5.2/go.mod h1:Uu9aa5UFAk1Ua+zZXnvzo+avDXuEi+GtegeOyja9xg4=
+github.com/Dynatrace/libbuildpack-dynatrace v1.8.0 h1:VNcd8+rurUUdY12emGfLGUUj5cMH4hkNgrdk8LO3dHE=
+github.com/Dynatrace/libbuildpack-dynatrace v1.8.0/go.mod h1:Uu9aa5UFAk1Ua+zZXnvzo+avDXuEi+GtegeOyja9xg4=
 github.com/GoogleCloudPlatform/docker-credential-gcr v2.0.5+incompatible/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/.gitignore
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# vim session file
+Session.vim

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/README.md
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/README.md
@@ -31,7 +31,9 @@ We support the following configuration fields,
 | apitoken      | string  | The API Token for the Dynatrace environment.                                                | Yes      | N/A             |
 | apiurl        | string  | Overrides the default Dynatrace API URL to connect to.                                      | No       | Default API URL |
 | skiperrors    | boolean | If true, the deployment doesn't fail if the Dynatrace agent download fails.                 | No       | false           |
-| networkzone      | string  | If set, agent is configured to choose communication endpoints located at the field's value. | No       | empty           |
+| networkzone   | string  | If set, agent is configured to choose communication endpoints located at the field's value. | No       | empty           |
+| enablefips    | boolean | If true, the [FIPS 140-2 mode](https://www.dynatrace.com/news/blog/dynatrace-achieves-fips-140-2-certification/) is enabled | No       | false           |
+| addtechnologies| string | Adds additional OneAgent code-modules via a comma-separated list. See [supported values](https://docs.dynatrace.com/docs/dynatrace-api/environment-api/deployment/oneagent/download-oneagent-version#parameters) in the "included" row | No | empty |
 
 For example,
 

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/unix.go
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/unix.go
@@ -1,0 +1,97 @@
+package dynatrace
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/cloudfoundry/libbuildpack"
+)
+
+func (h *Hook) runInstallerUnix(installerFilePath, installDir string, creds *credentials, stager *libbuildpack.Stager) error {
+	h.Log.Debug("Making %s executable...", installerFilePath)
+	err := os.Chmod(installerFilePath, 0755)
+	if err != nil {
+		h.Log.Error("Error while setting installer file %s executable", installerFilePath)
+		return err
+	}
+
+
+	h.Log.BeginStep("Starting Dynatrace OneAgent installer")
+
+	if os.Getenv("BP_DEBUG") != "" {
+		err = h.Command.Execute("", os.Stdout, os.Stderr, installerFilePath, stager.BuildDir())
+	} else {
+		err = h.Command.Execute("", io.Discard, io.Discard, installerFilePath, stager.BuildDir())
+	}
+	if err != nil {
+		return err
+	}
+
+	h.Log.Info("Dynatrace OneAgent installed.")
+
+	// Post-installation setup...
+
+	dynatraceEnvName := "dynatrace-env.sh"
+	dynatraceEnvPath := filepath.Join(stager.DepDir(), "profile.d", dynatraceEnvName)
+	agentLibPath, err := h.findAgentPath(filepath.Join(stager.BuildDir(), installDir), "process", "primary", "liboneagentproc.so", "linux-x86-64")
+	if err != nil {
+		h.Log.Error("Manifest handling failed!")
+		return err
+	}
+
+	agentLibPath = filepath.Join(installDir, agentLibPath)
+	agentBuilderLibPath := filepath.Join(stager.BuildDir(), agentLibPath)
+
+	if _, err = os.Stat(agentBuilderLibPath); os.IsNotExist(err) {
+		h.Log.Error("Agent library (%s) not found!", agentBuilderLibPath)
+		return err
+	}
+
+	h.Log.BeginStep("Setting up Dynatrace OneAgent injection...")
+	h.Log.Debug("Copy %s to %s", dynatraceEnvName, dynatraceEnvPath)
+	if err = libbuildpack.CopyFile(filepath.Join(stager.BuildDir(), installDir, dynatraceEnvName), dynatraceEnvPath); err != nil {
+		return err
+	}
+
+	h.Log.Debug("Open %s for modification...", dynatraceEnvPath)
+	f, err := os.OpenFile(dynatraceEnvPath, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	extra := ""
+
+	h.Log.Debug("Setting LD_PRELOAD...")
+	extra += fmt.Sprintf("\nexport LD_PRELOAD=${HOME}/%s", agentLibPath)
+
+	if creds.NetworkZone != "" {
+		h.Log.Debug("Setting DT_NETWORK_ZONE...")
+		extra += fmt.Sprintf("\nexport DT_NETWORK_ZONE=${DT_NETWORK_ZONE:-%s}", creds.NetworkZone)
+	}
+
+	// By default, OneAgent logs are printed to stderr. If the customer doesn't override this behavior through an
+	// environment variable, then we change the default output to stdout.
+	if os.Getenv("DT_LOGSTREAM") == "" {
+		h.Log.Debug("Setting DT_LOGSTREAM to stdout...")
+		extra += "\nexport DT_LOGSTREAM=stdout"
+	}
+
+	ver, err := stager.BuildpackVersion()
+	if err != nil {
+		h.Log.Warning("Failed to get buildpack version: %v", err)
+		ver = "unknown"
+	}
+	h.Log.Debug("Preparing custom properties...")
+	extra += fmt.Sprintf(
+		"\nexport DT_CUSTOM_PROP=\"${DT_CUSTOM_PROP} CloudFoundryBuildpackLanguage=%s CloudFoundryBuildpackVersion=%s\"", stager.BuildpackLanguage(), ver)
+
+	if _, err = f.WriteString(extra); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/Dynatrace/libbuildpack-dynatrace/windows.go
+++ b/vendor/github.com/Dynatrace/libbuildpack-dynatrace/windows.go
@@ -1,0 +1,99 @@
+package dynatrace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/cloudfoundry/libbuildpack"
+)
+
+func (h *Hook) runInstallerWindows(installerFilePath, installDir string, creds *credentials, stager *libbuildpack.Stager) error {
+	h.Log.BeginStep("Starting Dynatrace OneAgent installation")
+
+	h.Log.Info("Unzipping archive '%s' to '%s'", installerFilePath, filepath.Join(stager.BuildDir(), installDir))
+	err := libbuildpack.ExtractZip(installerFilePath, filepath.Join(stager.BuildDir(), installDir))
+	if err != nil {
+		h.Log.Error("Error during unzipping paas archive")
+		return err
+	}
+
+	h.Log.Info("Dynatrace OneAgent installed.")
+
+	// Post-installation setup...
+
+	h.Log.BeginStep("Setting up Dynatrace OneAgent injection...")
+	if slices.Contains(h.IncludeTechnologies, "dotnet") {
+		err = h.setUpDotNetCorProfilerInjection(creds, installDir, stager)
+	} else {
+		h.Log.Warning("No injection method available for technology stack")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *Hook) setUpDotNetCorProfilerInjection(creds *credentials, installDir string, stager *libbuildpack.Stager) error {
+	loaderPath, err := h.findAbsoluteLoaderPath(stager, installDir)
+	if err != nil {
+		return fmt.Errorf("cannot find oneagentloader.dll: %s", err)
+	}
+
+	scriptContent := "set COR_ENABLE_PROFILING=1\n"
+	scriptContent += "set COR_PROFILER={B7038F67-52FC-4DA2-AB02-969B3C1EDA03}\n"
+	scriptContent += "set DT_AGENTACTIVE=true\n"
+	scriptContent += "set DT_BLOCKLIST=powershell*\n"
+	scriptContent += fmt.Sprintf("set COR_PROFILER_PATH_64=%s\n", loaderPath)
+
+	if creds.NetworkZone != "" {
+		h.Log.Debug("Setting DT_NETWORK_ZONE...")
+		scriptContent += "set DT_NETWORK_ZONE=" + creds.NetworkZone + "\n"
+	}
+
+	ver, err := stager.BuildpackVersion()
+	if err != nil {
+		h.Log.Warning("Failed to get buildpack version: %v", err)
+		ver = "unknown"
+	}
+	h.Log.Debug("Preparing custom properties...")
+	scriptContent += fmt.Sprintf("set DT_CUSTOM_PROP=\"%%DT_CUSTOM_PROP%% CloudFoundryBuildpackLanguage=%s CloudFoundryBuildpackVersion=%s\"\n", stager.BuildpackLanguage(), ver)
+
+	stager.WriteProfileD("dynatrace-env.cmd", scriptContent)
+
+	return nil
+}
+
+func (h *Hook) findAbsoluteLoaderPath(stager *libbuildpack.Stager, installDir string) (string, error) {
+
+	// look for dotnet loader DLL file relative to the root of the downloaded zip archive
+	// and get the path from the manifest e.g. agent/bin/windows-x86-64/oneagentloader.dll
+	loaderDllPath, err := h.findAgentPath(filepath.Join(stager.BuildDir(), installDir), "dotnet", "loader", "oneagentloader.dll", "windows-x86-64")
+	if err != nil {
+		h.Log.Error("Manifest handling failed!")
+		return "", err
+	}
+
+	// windows path separator is "\" instead of "/"
+	loaderDllPath = strings.ReplaceAll(loaderDllPath, "/", "\\")
+
+	// build the loader DLL path relative to the app directory
+	// e.g. dynatrace/oneagent/agent/bin/windows-x86-64/oneagentloader.dll
+	loaderDllPathInAppDir := filepath.Join(installDir, loaderDllPath)
+
+	// check that the loader dll is present in the build dir
+	// e.g. at \tmp\app\dynatrace\oneagent\agent\bin\1.303.0.20240930-081133\windows-x86-32\oneagentloader.dll
+	loaderDllPathInBuildDir := filepath.Join(stager.BuildDir(), loaderDllPathInAppDir)
+
+	if _, err = os.Stat(loaderDllPathInBuildDir); os.IsNotExist(err) {
+		h.Log.Error("Agent library (%s) not found!", loaderDllPathInBuildDir)
+		return "", err
+	}
+
+	// build the absolute path of the loader DLL as it will be available at runtime
+	return filepath.Join("C:\\users\\vcap\\app", loaderDllPathInAppDir), nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # code.cloudfoundry.org/lager v2.0.0+incompatible
 ## explicit
 code.cloudfoundry.org/lager
-# github.com/Dynatrace/libbuildpack-dynatrace v1.5.2
+# github.com/Dynatrace/libbuildpack-dynatrace v1.8.0
 ## explicit; go 1.19
 github.com/Dynatrace/libbuildpack-dynatrace
 # github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
* A short explanation of the proposed change:
Bumps libbuildpack-dynatrace to v1.8.0

* An explanation of the use cases your change solves
This enables support for monitoring multi-buildpack and sidecar deployment scenarios with Dynatrace

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
