### PR TITLE
update default node version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 language: nodejs
 default_versions:
 - name: node
-  version: 18.x
+  version: 22.x
 - name: python
   version: 3.11.x
 include_files:


### PR DESCRIPTION
Updates the default node version to 22, if no engine is given.

Fixes #813 , #805

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
