### PR TITLE
Update default node version to 22

### DIFF
--- a/fixtures/util/override_buildpack/override.yml
+++ b/fixtures/util/override_buildpack/override.yml
@@ -1,7 +1,7 @@
 nodejs:
   dependencies:
   - name: node
-    version: 18.99.99
+    version: 22.99.99
     uri: https://buildpacks.cloudfoundry.org/dependencies/node/node.10.99.99-linux-x64.tgz
     file: BUILDPACK_DIR/node.tgz
     sha256: 062d906c87839d03b243e2821e10653c89b4c92878bfe2bf995dec231e117bfc

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 language: nodejs
 default_versions:
 - name: node
-  version: 18.x
+  version: 22.x
 - name: python
   version: 3.11.x
 include_files:

--- a/src/nodejs/integration/default_test.go
+++ b/src/nodejs/integration/default_test.go
@@ -57,7 +57,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 			}
 			Expect(json.NewDecoder(response.Body).Decode(&process)).To(Succeed())
 
-			Expect(process.Version).To(MatchRegexp(`v18\.\d+\.\d+`))
+			Expect(process.Version).To(MatchRegexp(`v22\.\d+\.\d+`))
 			Expect(process.Env.NodeOptions).To(BeEmpty())
 			Expect(process.Env.NodeHome).To(Equal("/home/vcap/deps/0/node"))
 			Expect(process.Env.NodeEnv).To(Equal("production"))

--- a/src/nodejs/integration/default_test.go
+++ b/src/nodejs/integration/default_test.go
@@ -38,7 +38,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 				Execute(name, filepath.Join(fixtures, "simple"))
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(logs).To(ContainLines(MatchRegexp("Installing node 18\\.\\d+\\.\\d+")))
+			Expect(logs).To(ContainLines(MatchRegexp("Installing node 22\\.\\d+\\.\\d+")))
 
 			Eventually(deployment).Should(Serve("Hello world!"))
 


### PR DESCRIPTION
Updates the default node version to 22, if no engine is given.

Fixes https://github.com/cloudfoundry/nodejs-buildpack/issues/813 , https://github.com/cloudfoundry/nodejs-buildpack/issues/805

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
