### PR TITLE
Add check for existing CF CLI installation

### DIFF
--- a/scripts/.util/tools.sh
+++ b/scripts/.util/tools.sh
@@ -148,10 +148,17 @@ function util::tools::cf::install() {
       exit 1
   esac
 
+# Check if cf is already available in PATH (e.g., from system/Docker image)
+  if command -v cf &> /dev/null; then
+    util::print::title "CF CLI already installed (using system version)"
+    cf version
+    return 0
+  fi
+
   if [[ ! -f "${dir}/cf" ]]; then
     util::print::title "Installing cf"
 
-    curl "https://packages.cloudfoundry.org/stable?release=${os}-binary&version=6.49.0&source=github-rel" \
+    curl "https://packages.cloudfoundry.org/stable?release=${os}-binary&source=github-rel" \
       --silent \
       --location \
       --output /tmp/cf.tar.gz


### PR DESCRIPTION
Added a check to see if CF CLI is already installed in PATH before attempting to install it.