### PR TITLE
Fix CF CLI installation to use system version when available

### DIFF
--- a/scripts/.util/tools.sh
+++ b/scripts/.util/tools.sh
@@ -148,10 +148,17 @@ function util::tools::cf::install() {
       exit 1
   esac
 
+  # Check if cf already exists in the target directory or system PATH
+  if [[ -f "${dir}/cf" ]] || command -v cf >/dev/null 2>&1; then
+    util::print::title "CF CLI already installed (using system version)"
+    cf version
+    return 0
+  fi
+
   if [[ ! -f "${dir}/cf" ]]; then
     util::print::title "Installing cf"
 
-    curl "https://packages.cloudfoundry.org/stable?release=${os}-binary&version=6.49.0&source=github-rel" \
+    curl "https://packages.cloudfoundry.org/stable?release=${os}-binary&source=github-rel" \
       --silent \
       --location \
       --output /tmp/cf.tar.gz


### PR DESCRIPTION
## What is this change about?

This PR fixes a critical issue in the CF CLI installation logic that causes integration test failures in BBL-based CI environments.

## Problem

When running integration tests against a real CF environment (not Docker), the current `util::tools::cf::install()` function:

1. **Always installs a fresh CF CLI** to `.bin/cf`, even when CF CLI is already available in the system
2. **Uses an outdated version** (hardcoded CF v6.49.0 from 2020)
3. **Overwrites the authenticated CF session** created by the `cf-space/login` script
4. Results in error: `No API endpoint set. Use 'cf login' or 'cf api' to target an endpoint.`

This only affects the nodejs-buildpack because:
- The r-buildpack has a similar fix (added Nov 24, 2025)
- Our previous fix in PR #856 was **reverted by an automated github-config sync** on Dec 9, 2025

## Solution

This PR adds a check to detect if CF CLI is already installed before attempting to download it:

```bash
# Check if cf already exists in the target directory or system PATH
if [[ -f "${dir}/cf" ]] || command -v cf >/dev/null 2>&1; then
  util::print::title "CF CLI already installed (using system version)"
  cf version
  return 0
fi
```

## Additionally:
 - Removes the hardcoded version=6.49.0 parameter
 - Fetches the latest stable CF CLI release instead
 - Preserves the authenticated CF session from the CI environment

### Testing
✅ Integration tests now pass in BBL environments (nodejs.buildpacks.ci.cloudfoundry.org)
✅ CF authentication is preserved throughout the test run
✅ System CF CLI v8.17.0 is detected and reused
✅ No "Installing cf" message appears when system CF is available

### Related Issues
Fixes integration test failures in specs-edge-integration-master-cflinuxfs4 job
Related to PR #856 (reverted by github-config sync)
Matches the fix in r-buildpack (commit cce4022)

## Follow-up Actions
⚠️ Important: This fix needs to be submitted to cloudfoundry/buildpacks-github-config repository to prevent future automated reverts. The daily github-config sync workflow will otherwise overwrite this change again.

Until the fix is merged in github-config, this PR should be maintained in the nodejs-buildpack to keep integration tests working.

Checklist
 ✅ Code follows the project's style guidelines
 ✅ Tests pass locally and in CI
 ✅ Documentation updated (inline comments added)
 ✅ Corresponding fix needs to be submitted to buildpacks-github-config
