### PR TITLE
Add --retry-all-errors option when downloading Go binary

### DIFF
--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -29,6 +29,7 @@ function main() {
       --silent \
       --location \
       --retry 15 \
+      --retry-all-errors \
       --retry-delay 2 \
       --output "/tmp/go.tgz"
 


### PR DESCRIPTION
## Add --retry-all-errors option when downloading Go binary
### Summary
Added the --retry-all-errors flag to the curl command that downloads the Go binary in `install_go.sh`

### Problem
The current implementation uses curl `--retry 15` which only retries on specific transient errors (timeouts, 5xx responses). However, it does not retry on other errors such as:
 - Connection reset by peer (TCP/IP issues)
 - Temporary DNS resolution failures
 - SSL handshake errors
This can cause builds to fail unnecessarily when transient network issues occur. This behaviour is explained in the issue #626 

### Solution
Adding `--retry-all-errors` makes curl retry on any error response, not just the default set. This significantly improves resilience when downloading from the well-known and trusted URL https://buildpacks.cloudfoundry.org/dependencies/go.

### Benefits
More reliable builds in environments with intermittent network connectivity
Reduces false-positive build failures due to transient network issues
No breaking changes - the download still validates SHA256 checksum after successful retrieval
### Testing
The change maintains existing behavior for successful downloads while adding retry capability for previously non-retryable errors.
